### PR TITLE
When we can use a shader cache, optimize and cache the clc context

### DIFF
--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -185,6 +185,11 @@ struct clc_context *clc_context_new(const struct clc_logger *logger);
 
 void clc_free_context(struct clc_context *ctx);
 
+void clc_context_optimize(struct clc_context *ctx);
+void clc_context_serialize(struct clc_context *ctx, void **serialized, size_t *size);
+void clc_context_free_serialized(void *serialized);
+struct clc_context *clc_context_deserialize(void *serialized, size_t size);
+
 struct clc_object *
 clc_compile(struct clc_context *ctx,
             const struct clc_compile_args *args,
@@ -248,6 +253,8 @@ struct clc_work_properties_data {
    unsigned group_id_offset_y;
    unsigned group_id_offset_z;
 };
+
+uint64_t clc_compiler_get_version();
 
 #ifdef __cplusplus
 }

--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -28,6 +28,8 @@ public:
     FoundValue Find(const void* key, size_t keySize);
     FoundValue Find(const void* const* keys, const size_t* keySizes, unsigned keyParts);
 
+    void Close();
+
 #ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
 private:
     Microsoft::WRL::ComPtr<ID3D12ShaderCacheSession> m_pSession;

--- a/include/cache.hpp
+++ b/include/cache.hpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include "d3d12.h"
+#include <memory>
+#include <utility>
+#include <wrl/client.h>
+
+class ShaderCache
+{
+public:
+    ShaderCache(ID3D12Device*);
+
+    bool HasCache() const
+    {
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+        return m_pSession;
+#else
+        return false;
+#endif
+    }
+
+    void Store(const void* key, size_t keySize, const void* value, size_t valueSize) noexcept;
+    void Store(const void* const* keys, const size_t* keySizes, unsigned keyParts, const void* value, size_t valueSize);
+
+    using FoundValue = std::pair<std::unique_ptr<byte[]>, size_t>;
+    FoundValue Find(const void* key, size_t keySize);
+    FoundValue Find(const void* const* keys, const size_t* keySizes, unsigned keyParts);
+
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+private:
+    Microsoft::WRL::ComPtr<ID3D12ShaderCacheSession> m_pSession;
+#endif
+};

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include "platform.hpp"
+#include "cache.hpp"
 #include <string>
 #include <optional>
 #include <mutex>
@@ -24,6 +25,7 @@ public:
     bool IsMCDM() const noexcept;
     bool IsUMA();
     bool SupportsInt16();
+    ShaderCache& GetShaderCache();
 
     std::string GetDeviceName() const;
 
@@ -61,6 +63,7 @@ protected:
     std::unique_ptr<Submission> m_RecordingSubmission;
 
     BackgroundTaskScheduler::Scheduler m_CompletionScheduler;
+    std::optional<ShaderCache> m_ShaderCache;
 
     // All PSO creations need to be kicked off behind this lock,
     // which guards the root signature cache in the immediate context

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -108,7 +108,7 @@ public:
     cl_device_id GetDevice(cl_uint i) const noexcept;
     XPlatHelpers::unique_module const& GetCompiler();
     XPlatHelpers::unique_module const& GetDXIL();
-    clc_context* GetCompilerContext();
+    clc_context* GetCompilerContext(class ShaderCache&);
     void UnloadCompiler();
 
     TaskPoolLock GetTaskPoolLock();

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -115,6 +115,7 @@ public:
     void FlushAllDevices(TaskPoolLock const& Lock);
 
     bool AnyD3DDevicesExist() const noexcept;
+    void CloseCaches();
 
     class ref_int
     {

--- a/include/program.hpp
+++ b/include/program.hpp
@@ -119,6 +119,7 @@ private:
 
     struct PerDeviceData
     {
+        Device* m_Device;
         cl_build_status m_BuildStatus = CL_BUILD_IN_PROGRESS;
         std::string m_BuildLog;
         unique_spirv m_OwnedBinary{ nullptr, nullptr };

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include "platform.hpp"
+#include "cache.hpp"
+#include "clc_compiler.h"
+#include <numeric>
+
+#pragma warning(disable: 4100)
+
+ShaderCache::ShaderCache(ID3D12Device* d)
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    ComPtr<ID3D12Device9> device9;
+    if (FAILED(d->QueryInterface(device9.ReleaseAndGetAddressOf())))
+        return;
+
+    D3D12_SHADER_CACHE_SESSION_DESC Desc = {};
+    // {17CB474E-4C55-4DBC-BC2E-D5132115BDA3}
+    Desc.Identifier = { 0x17cb474e, 0x4c55, 0x4dbc, { 0xbc, 0x2e, 0xd5, 0x13, 0x21, 0x15, 0xbd, 0xa3 } };
+    Desc.Mode = D3D12_SHADER_CACHE_MODE_DISK;
+
+    auto& Compiler = g_Platform->GetCompiler();
+    auto pfnGetVersion = Compiler.proc_address<decltype(&clc_compiler_get_version)>("clc_compiler_get_version");
+    if (pfnGetVersion)
+    {
+        Desc.Version = pfnGetVersion();
+    }
+#if _WIN32
+    else
+    {
+        WCHAR FileName[MAX_PATH];
+        DWORD FileNameLength = GetModuleFileNameW(Compiler.get(), FileName, ARRAYSIZE(FileName));
+
+        if (FileNameLength != 0 && FileNameLength != ARRAYSIZE(FileName))
+        {
+            HANDLE hFile = CreateFileW(FileName, GENERIC_READ, FILE_SHARE_READ,
+                                       nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+            if (hFile != INVALID_HANDLE_VALUE)
+            {
+                FILETIME Time = {};
+                GetFileTime(hFile, nullptr, nullptr, &Time);
+                CloseHandle(hFile);
+                Desc.Version = reinterpret_cast<UINT64&>(Time);
+            }
+        }
+    }
+#endif
+
+    (void)device9->CreateShaderCacheSession(&Desc, IID_PPV_ARGS(&m_pSession));
+#endif
+}
+
+void ShaderCache::Store(const void* key, size_t keySize, const void* value, size_t valueSize) noexcept
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    if (m_pSession)
+    {
+        (void)m_pSession->StoreValue(key, (UINT)keySize, value, (UINT)valueSize);
+    }
+#endif
+}
+
+void ShaderCache::Store(const void* const* keys, const size_t* keySizes, unsigned keyParts, const void* value, size_t valueSize)
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    if (m_pSession)
+    {
+        size_t combinedSize = std::accumulate(keySizes, keySizes + keyParts, (size_t)0);
+        std::unique_ptr<byte[]> combinedKey(new byte[combinedSize]);
+
+        unsigned i = 0;
+        for (byte* ptr = combinedKey.get(); ptr != combinedKey.get() + combinedSize; ptr += keySizes[i++])
+        {
+            memcpy(ptr, keys[i], keySizes[i]);
+        }
+
+        Store(combinedKey.get(), combinedSize, value, valueSize);
+    }
+#endif
+}
+
+ShaderCache::FoundValue ShaderCache::Find(const void* key, size_t keySize)
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    if (m_pSession)
+    {
+        UINT valueSize = 0;
+        if (SUCCEEDED(m_pSession->FindValue(key, (UINT)keySize, nullptr, &valueSize)))
+        {
+            ShaderCache::FoundValue value(new byte[valueSize], valueSize);
+            if (SUCCEEDED(m_pSession->FindValue(key, (UINT)keySize, value.first.get(), &valueSize)))
+            {
+                return value;
+            }
+        }
+    }
+#endif
+    return {};
+}
+
+ShaderCache::FoundValue ShaderCache::Find(const void* const* keys, const size_t* keySizes, unsigned keyParts)
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    if (m_pSession)
+    {
+        size_t combinedSize = std::accumulate(keySizes, keySizes + keyParts, (size_t)0);
+        std::unique_ptr<byte[]> combinedKey(new byte[combinedSize]);
+
+        unsigned i = 0;
+        for (byte* ptr = combinedKey.get(); ptr != combinedKey.get() + combinedSize; ptr += keySizes[i++])
+        {
+            memcpy(ptr, keys[i], keySizes[i]);
+        }
+
+        return Find(combinedKey.get(), combinedSize);
+    }
+#endif
+    return {};
+}

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -119,3 +119,10 @@ ShaderCache::FoundValue ShaderCache::Find(const void* const* keys, const size_t*
 #endif
     return {};
 }
+
+void ShaderCache::Close()
+{
+#ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
+    m_pSession.Reset();
+#endif
+}

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -267,6 +267,7 @@ void Device::InitD3D()
         (INT64)Task::TimestampToNanoseconds(GPUTimestamp, m_TimestampFrequency);
 
     m_RecordingSubmission.reset(new Submission);
+    m_ShaderCache.emplace(GetDevice());
 }
 
 void Device::ReleaseD3D()
@@ -282,6 +283,7 @@ void Device::ReleaseD3D()
     m_CompletionScheduler.SetSchedulingMode(mode);
     m_RecordingSubmission.reset();
     m_spDevice.Reset();
+    m_ShaderCache.reset();
 }
 
 cl_bool Device::IsAvailable() const noexcept
@@ -335,6 +337,11 @@ bool Device::SupportsInt16()
         CacheCaps(Lock);
     }
     return m_D3D12Options4.Native16BitShaderOpsSupported;
+}
+
+ShaderCache& Device::GetShaderCache()
+{
+    return *m_ShaderCache;
 }
 
 std::string Device::GetDeviceName() const

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -257,7 +257,7 @@ public:
                 try
                 {
                     auto& Compiler = g_Platform->GetCompiler();
-                    auto Context = g_Platform->GetCompilerContext();
+                    auto Context = g_Platform->GetCompilerContext(Device.GetShaderCache());
                     auto get_kernel = Compiler.proc_address<decltype(&clc_to_dxil)>("clc_to_dxil");
                     auto free = Compiler.proc_address<decltype(&clc_free_dxil_object)>("clc_free_dxil_object");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,7 +281,12 @@ extern "C" extern BOOL WINAPI DllMain(HINSTANCE, UINT dwReason, LPVOID lpReserve
         // the platform, just go ahead and leak them, rather than trying
         // to clean them up.
         if (lpReserved && g_Platform->AnyD3DDevicesExist())
+        {
+            // At the very least close shader caches cleanly so they can be flushed
+            // to disk.
+            g_Platform->CloseCaches();
             return TRUE;
+        }
 
         delete g_Platform;
     }

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -291,3 +291,14 @@ bool Platform::AnyD3DDevicesExist() const noexcept
 {
     return std::any_of(m_Devices.begin(), m_Devices.end(), [](auto& dev) { return dev->GetDevice(); });
 }
+
+void Platform::CloseCaches()
+{
+    for (auto& device : m_Devices)
+    {
+        if (device->GetDevice())
+        {
+            device->GetShaderCache().Close();
+        }
+    }
+}


### PR DESCRIPTION
This requires https://gitlab.freedesktop.org/kusma/mesa/-/merge_requests/309. It's at least part of the fix for #8, we should also cache the CLC -> SPIR-V and SPIR-V -> DXIL compilation steps, but that can come later.