### PR TITLE
Update header to new API proposed during CL compiler upstreaming

### DIFF
--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -178,14 +178,17 @@ struct clc_dxil_object {
 };
 
 struct clc_context {
-   void *libclc_nir;
+   const void *libclc_nir;
 };
 
-struct clc_context *clc_context_new(const struct clc_logger *logger);
+struct clc_context_options {
+   unsigned optimize;
+};
+
+struct clc_context *clc_context_new(const struct clc_logger *logger, const struct clc_context_options *options);
 
 void clc_free_context(struct clc_context *ctx);
 
-void clc_context_optimize(struct clc_context *ctx);
 void clc_context_serialize(struct clc_context *ctx, void **serialized, size_t *size);
 void clc_context_free_serialized(void *serialized);
 struct clc_context *clc_context_deserialize(void *serialized, size_t size);


### PR DESCRIPTION
From comments on Mesa upstreaming merge request (https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/7565#note_693746), switching optimization to an option during context creation, rather than a separate step.