### PR TITLE
Pick up new printf metadata from Mesa upstream

### DIFF
--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -118,6 +118,12 @@ struct clc_object {
 #define CLC_MAX_BINDINGS_PER_ARG 3
 #define CLC_MAX_SAMPLERS 16
 
+struct clc_printf_format_string {
+   unsigned num_args;
+   unsigned *arg_sizes;
+   char *str;
+};
+
 struct clc_dxil_metadata {
    struct {
       unsigned offset;
@@ -165,7 +171,13 @@ struct clc_dxil_metadata {
    uint16_t local_size[3];
    uint16_t local_size_hint[3];
 
-   int printf_uav_id;
+   struct {
+      unsigned string_arg_count;
+      char **string_args;
+      unsigned fmt_string_count;
+      struct clc_printf_format_string *fmt_strings;
+      unsigned uav_id;
+   } printf;
 };
 
 struct clc_dxil_object {

--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -174,7 +174,7 @@ struct clc_dxil_metadata {
    struct {
       unsigned info_count;
       struct clc_printf_info *infos;
-      unsigned uav_id;
+      int uav_id;
    } printf;
 };
 

--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -172,8 +172,8 @@ struct clc_dxil_metadata {
    uint16_t local_size_hint[3];
 
    struct {
-      unsigned string_arg_count;
-      char **string_args;
+      unsigned string_arg_size;
+      char *string_args;
       unsigned fmt_string_count;
       struct clc_printf_format_string *fmt_strings;
       unsigned uav_id;

--- a/external/clc_compiler.h
+++ b/external/clc_compiler.h
@@ -118,7 +118,7 @@ struct clc_object {
 #define CLC_MAX_BINDINGS_PER_ARG 3
 #define CLC_MAX_SAMPLERS 16
 
-struct clc_printf_format_string {
+struct clc_printf_info {
    unsigned num_args;
    unsigned *arg_sizes;
    char *str;
@@ -172,10 +172,8 @@ struct clc_dxil_metadata {
    uint16_t local_size_hint[3];
 
    struct {
-      unsigned string_arg_size;
-      char *string_args;
-      unsigned fmt_string_count;
-      struct clc_printf_format_string *fmt_strings;
+      unsigned info_count;
+      struct clc_printf_info *infos;
       unsigned uav_id;
    } printf;
 };

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -760,7 +760,7 @@ void ExecuteKernel::OnComplete()
                 // Get the base pointer to the arg, now that we know how big it is
                 uint32_t ArgSize = PromotedDataSize * (VectorSize == 3 ? 4 : VectorSize);
                 assert(ArgSize == FormatStringData.arg_sizes[ArgIdx]);
-                uint32_t ArgOffset = D3D12TranslationLayer::Align<uint32_t>(OffsetInStruct, ArgSize) + StructBeginOffset;
+                uint32_t ArgOffset = D3D12TranslationLayer::Align<uint32_t>(OffsetInStruct, 4) + StructBeginOffset;
                 byte* ArgPtr = ByteStream + ArgOffset;
                 OffsetInStruct += ArgSize;
 
@@ -867,7 +867,6 @@ void ExecuteKernel::OnComplete()
                 }
 
                 SectionStart = FormatStr + 1;
-                OffsetInStruct += ArgSize;
                 ArgIdx++;
             }
 

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -781,8 +781,8 @@ void ExecuteKernel::OnComplete()
                             return;
                         }
                         uint64_t StringId = *reinterpret_cast<uint64_t*>(ArgPtr);
-                        assert(StringId > 0 && StringId <= m_Kernel->m_pDxil->metadata.printf.string_arg_count);
-                        const char *Str = m_Kernel->m_pDxil->metadata.printf.string_args[StringId - 1];
+                        assert(StringId < m_Kernel->m_pDxil->metadata.printf.string_arg_size);
+                        const char *Str = &m_Kernel->m_pDxil->metadata.printf.string_args[StringId];
                         // Use sprintf to deal with precision potentially shortening how much is printed
                         StringBuffer.resize(snprintf(nullptr, 0, FinalFormatString, Str) + 1);
                         sprintf_s(StringBuffer.data(), StringBuffer.size(), FinalFormatString, Str);

--- a/test/openclon12test.cpp
+++ b/test/openclon12test.cpp
@@ -183,6 +183,28 @@ TEST(OpenCLOn12, LargeDispatch)
     }
 }
 
+TEST(OpenCLOn12, Printf)
+{
+    auto&& [context, device] = GetWARPContext();
+    cl::CommandQueue queue(context, device);
+
+    const char* kernel_source =
+    R"(
+    constant uchar arr[6] = {'c', 'l', 'o', 'n', '1', '2'};
+    kernel void test_printf() {
+	    printf("hello %d %f %s %s %c\n", 15, 1.5, "test", "this string", arr[3]);
+	    printf("goodbye %d %f %s %c %s\n", 30, -1.5, "cruel", arr[2], "world");
+        printf("hello cl\n", 10, "oh now");
+        printf("hello cl %s\n", "again");
+    })";
+
+    cl::Program program(context, kernel_source, true /*build*/);
+    cl::Kernel kernel(program, "test_printf");
+
+    queue.enqueueTask(kernel);
+    queue.finish();
+}
+
 int main(int argc, char** argv)
 {
     ID3D12Debug* pDebug = nullptr;


### PR DESCRIPTION
Strings are now copied into metadata rather than letting the runtime just find them based on pointer value (which Clover drivers can't do).

Exporting the arg sizes as well allows us to fix #5 (both problems) with this change as well.