### PR TITLE
Implement CL 3.0

### DIFF
--- a/include/context.hpp
+++ b/include/context.hpp
@@ -13,12 +13,22 @@ public:
         size_t       cb,
         void *       user_data);
 
+    struct DestructorCallback
+    {
+        using Fn = void(CL_CALLBACK *)(cl_context, void*);
+        Fn m_pfn;
+        void* m_userData;
+    };
+
 private:
     std::vector<Device::ref_ptr_int> m_AssociatedDevices;
     const PfnCallbackType m_ErrorCallback;
     void* const m_CallbackContext;
 
     std::vector<cl_context_properties> const m_Properties;
+
+    mutable std::mutex m_DestructorLock;
+    std::vector<DestructorCallback> m_DestructorCallbacks;
 
     static void CL_CALLBACK DummyCallback(const char*, const void*, size_t, void*) {}
 
@@ -56,4 +66,6 @@ public:
     Device& GetDevice(cl_uint index) const noexcept;
     bool ValidDeviceForContext(Device& device) const noexcept;
     std::vector<Device::ref_ptr_int> GetDevices() const noexcept { return m_AssociatedDevices; }
+
+    void AddDestructionCallback(DestructorCallback::Fn pfn, void* pUserData);
 };

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -25,6 +25,7 @@ public:
     bool IsMCDM() const noexcept;
     bool IsUMA();
     bool SupportsInt16();
+    bool SupportsTypedUAVLoad();
     ShaderCache& GetShaderCache();
 
     std::string GetDeviceName() const;

--- a/include/kernel.hpp
+++ b/include/kernel.hpp
@@ -28,10 +28,6 @@ private:
     std::vector<::ref_ptr<Sampler>> m_ConstSamplers;
     std::vector<::ref_ptr<Resource>> m_InlineConsts;
 
-    // TODO: Consider moving this to the program so it can be shared
-    // across multiple kernel instances for the same kernel name,
-    // or clCloneKernel instances when we get there.
-
     friend class ExecuteKernel;
     friend extern CL_API_ENTRY cl_int CL_API_CALL clGetKernelInfo(cl_kernel, cl_kernel_info, size_t, void*, size_t*);
     friend extern CL_API_ENTRY cl_int CL_API_CALL clGetKernelArgInfo(cl_kernel, cl_uint, cl_kernel_arg_info, size_t, void*, size_t*);
@@ -39,6 +35,7 @@ private:
 
 public:
     Kernel(Program& Parent, std::string const& name, clc_dxil_object const* pDxil);
+    Kernel(Kernel const&);
     ~Kernel();
 
     cl_int SetArg(cl_uint arg_index, size_t arg_size, const void* arg_value);

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -108,7 +108,13 @@ public:
     static constexpr const char* Version = "OpenCL 1.2 D3D12 Implementation";
     static constexpr const char* Name = "OpenCLOn12";
     static constexpr const char* Vendor = "Microsoft";
-    static constexpr const char* Extensions = "cl_khr_icd";
+    static constexpr const char* Extensions = "cl_khr_icd "
+                                              "cl_khr_extended_versioning "
+                                              "cl_khr_global_int32_base_atomics "
+                                              "cl_khr_global_int32_extended_atomics "
+                                              "cl_khr_local_int32_base_atomics "
+                                              "cl_khr_local_int32_extended_atomics "
+                                              "cl_khr_byte_addressable_store ";
     static constexpr const char* ICDSuffix = "oclon12";
 
     Platform(cl_icd_dispatch* dispatch);

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -6,6 +6,16 @@
 #define CL_USE_DEPRECATED_OPENCL_1_0_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_2_2_APIS
+
+#ifdef CLON12_SUPPORT_3_0
+#define CL_TARGET_OPENCL_VERSION 300
+#else
+// Choosing 2.2 since we have stubs for everything currently
+#define CL_TARGET_OPENCL_VERSION 220
+#endif
 
 #include <D3D12TranslationLayerDependencyIncludes.h>
 #include <D3D12TranslationLayerIncludes.h>

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -105,7 +105,11 @@ class Platform : public CLBase<Platform, cl_platform_id>
 {
 public:
     static constexpr const char* Profile = "FULL_PROFILE";
+#ifdef CLON12_SUPPORT_3_0
+    static constexpr const char* Version = "OpenCL 3.0 D3D12 Implementation";
+#else
     static constexpr const char* Version = "OpenCL 1.2 D3D12 Implementation";
+#endif
     static constexpr const char* Name = "OpenCLOn12";
     static constexpr const char* Vendor = "Microsoft";
     static constexpr const char* Extensions = "cl_khr_icd "
@@ -347,6 +351,10 @@ inline cl_int CopyOutParameter(const T(&value)[size], size_t param_value_size, v
 inline cl_int CopyOutParameter(const char* value, size_t param_value_size, void* param_value, size_t* param_value_size_ret)
 {
     return CopyOutParameterImpl(value, strlen(value) + 1, param_value_size, param_value, param_value_size_ret);
+}
+inline cl_int CopyOutParameter(nullptr_t, size_t param_value_size, void* param_value, size_t *param_value_size_ret)
+{
+    return CopyOutParameterImpl(nullptr, 0, param_value_size, param_value, param_value_size_ret);
 }
 
 inline bool IsZeroOrPow2(cl_bitfield bits)

--- a/include/program.hpp
+++ b/include/program.hpp
@@ -165,6 +165,7 @@ private:
         std::vector<Device::ref_ptr_int> BinaryBuildDevices;
     };
 
+    void AddBuiltinOptions(std::vector<Device::ref_ptr_int> const& devices, CommonOptions& optionsStruct);
     cl_int ParseOptions(const char* optionsStr, CommonOptions& optionsStruct, bool SupportCompilerOptions, bool SupportLinkerOptions);
     cl_int BuildImpl(BuildArgs const& Args);
     cl_int CompileImpl(CompileArgs const& Args);

--- a/include/queue.hpp
+++ b/include/queue.hpp
@@ -9,7 +9,7 @@
 class CommandQueue : public CLChildBase<CommandQueue, Device, cl_command_queue>
 {
 public:
-    CommandQueue(Device& device, Context& context, const cl_queue_properties* properties);
+    CommandQueue(Device& device, Context& context, const cl_queue_properties* properties, bool synthesizedProperties);
 
     friend cl_int CL_API_CALL clGetCommandQueueInfo(cl_command_queue, cl_command_queue_info, size_t, void*, size_t*);
 
@@ -23,6 +23,7 @@ public:
 
     const bool m_bOutOfOrder;
     const bool m_bProfile;
+    const bool m_bPropertiesSynthesized;
     std::vector<cl_queue_properties> const m_Properties;
 
 protected:

--- a/include/sampler.hpp
+++ b/include/sampler.hpp
@@ -13,11 +13,12 @@ public:
         cl_addressing_mode AddressingMode;
         cl_filter_mode FilterMode;
     };
-    Sampler(Context& Parent, Desc const& desc);
+    Sampler(Context& Parent, Desc const& desc, const cl_sampler_properties *properties);
 
     D3D12TranslationLayer::Sampler& GetUnderlying(Device*);
 
     const Desc m_Desc;
+    const std::vector<cl_sampler_properties> m_Properties;
 private:
     std::mutex m_Lock;
     std::unordered_map<class Device*, D3D12TranslationLayer::Sampler> m_UnderlyingSamplers;

--- a/include/task.hpp
+++ b/include/task.hpp
@@ -72,6 +72,7 @@ class Task : public CLChildBase<Task, Context, cl_event>
     };
 
 public:
+    struct DependencyException {};
     friend class Device;
     enum class State
     {

--- a/src/OpenCLOn12.def
+++ b/src/OpenCLOn12.def
@@ -144,3 +144,8 @@ clSetDefaultDeviceCommandQueue
 ; OpenCL 2.2 API
 clSetProgramReleaseCallback
 clSetProgramSpecializationConstant
+
+; OpenCL 3.0 API
+clCreateBufferWithProperties
+clCreateImageWithProperties
+clSetContextDestructorCallback

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -596,25 +596,3 @@ clGetHostTimer(cl_device_id device,
     *host_timestamp = QPC.QuadPart;
     return CL_SUCCESS;
 }
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clCreateSubDevices(cl_device_id                         in_device,
-    const cl_device_partition_property * properties,
-    cl_uint                              num_devices,
-    cl_device_id *                       out_devices,
-    cl_uint *                            num_devices_ret) CL_API_SUFFIX__VERSION_1_2
-{
-    if (!in_device)
-    {
-        return CL_INVALID_DEVICE;
-    }
-    if (properties && properties[0] != 0)
-    {
-        // We don't support any of the partition modes, so the spec says we should return this
-        return CL_INVALID_VALUE;
-    }
-    UNREFERENCED_PARAMETER(num_devices);
-    UNREFERENCED_PARAMETER(out_devices);
-    UNREFERENCED_PARAMETER(num_devices_ret);
-    return CL_INVALID_DEVICE_PARTITION_COUNT;
-}

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -115,8 +115,8 @@ clGetDeviceInfo(cl_device_id    device,
 
         case CL_DEVICE_IMAGE_SUPPORT: return ImageRetValue((cl_bool)CL_TRUE, (cl_bool)CL_FALSE);
         case CL_DEVICE_MAX_READ_IMAGE_ARGS: /*SRVs*/ return ImageRetValueOrZero((cl_uint)128);
-        case CL_DEVICE_MAX_WRITE_IMAGE_ARGS: // Fallthrough
-        case CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: /*UAVs*/ return ImageRetValueOrZero((cl_uint)64);
+        case CL_DEVICE_MAX_WRITE_IMAGE_ARGS: /*UAVs*/return ImageRetValueOrZero((cl_uint)64);
+        case CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: /*Typed UAVs*/ return ImageRetValueOrZero((cl_uint)(pDevice->SupportsTypedUAVLoad() ? 64 : 0));
 
         case CL_DEVICE_IL_VERSION: return RetValue("");
 
@@ -337,6 +337,15 @@ bool Device::SupportsInt16()
         CacheCaps(Lock);
     }
     return m_D3D12Options4.Native16BitShaderOpsSupported;
+}
+
+bool Device::SupportsTypedUAVLoad()
+{
+    {
+        std::lock_guard Lock(m_InitLock);
+        CacheCaps(Lock);
+    }
+    return m_D3D12Options.TypedUAVLoadAdditionalFormats;
 }
 
 ShaderCache& Device::GetShaderCache()

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -119,6 +119,7 @@ clGetDeviceInfo(cl_device_id    device,
         case CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: /*Typed UAVs*/ return ImageRetValueOrZero((cl_uint)(pDevice->SupportsTypedUAVLoad() ? 64 : 0));
 
         case CL_DEVICE_IL_VERSION: return RetValue("");
+        case CL_DEVICE_ILS_WITH_VERSION: return RetValue(nullptr);
 
         case CL_DEVICE_IMAGE2D_MAX_WIDTH: return ImageRetValueOrZero((size_t)D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
         case CL_DEVICE_IMAGE2D_MAX_HEIGHT: return ImageRetValueOrZero((size_t)D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
@@ -176,13 +177,27 @@ clGetDeviceInfo(cl_device_id    device,
         case CL_DEVICE_MAX_ON_DEVICE_EVENTS: return RetValue((cl_uint)0);
 
         case CL_DEVICE_BUILT_IN_KERNELS: return RetValue("");
+        case CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: return RetValue(nullptr);
         case CL_DEVICE_PLATFORM: return RetValue(static_cast<cl_platform_id>(&pDevice->m_Parent.get()));
         case CL_DEVICE_NAME: return RetValue(pDevice->GetDeviceName().c_str());
         case CL_DEVICE_VENDOR: return RetValue(pDevice->m_Parent->Vendor);
-        case CL_DRIVER_VERSION: return RetValue("1.0.0");
+        case CL_DRIVER_VERSION: return RetValue("1.1.0");
         case CL_DEVICE_PROFILE: return RetValue(pDevice->m_Parent->Profile);
         case CL_DEVICE_VERSION: return RetValue(pDevice->m_Parent->Version);
         case CL_DEVICE_OPENCL_C_VERSION: return RetValue("OpenCL C 1.2 ");
+        case CL_DEVICE_OPENCL_C_ALL_VERSIONS:
+        {
+            constexpr cl_name_version versions[] =
+            {
+                { CL_MAKE_VERSION(1, 0, 0), "OpenCL C" },
+                { CL_MAKE_VERSION(1, 1, 0), "OpenCL C" },
+                { CL_MAKE_VERSION(1, 2, 0), "OpenCL C" },
+#ifdef CLON12_SUPPORT_3_0
+                { CL_MAKE_VERSION(3, 0, 0), "OpenCL C" },
+#endif
+            };
+            return RetValue(versions);
+        }
 
         case CL_DEVICE_EXTENSIONS: return RetValue("cl_khr_global_int32_base_atomics "
                                                    "cl_khr_global_int32_extended_atomics "
@@ -211,6 +226,27 @@ clGetDeviceInfo(cl_device_id    device,
         case CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: return RetValue((cl_bool)CL_FALSE);
 
         case CL_DEVICE_HOST_UNIFIED_MEMORY: return RetValue((cl_bool)pDevice->IsUMA());
+
+        case CL_DEVICE_MAX_PIPE_ARGS: return RetValue((cl_uint)0);
+        case CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: return RetValue((cl_uint)0);
+        case CL_DEVICE_PIPE_MAX_PACKET_SIZE: return RetValue((cl_uint)0);
+
+        case CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: return RetValue((cl_device_atomic_capabilities)(
+            CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_ORDER_ACQ_REL | CL_DEVICE_ATOMIC_ORDER_SEQ_CST |
+            CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE));
+        case CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: return RetValue((cl_device_atomic_capabilities)(
+            CL_DEVICE_ATOMIC_ORDER_RELAXED | CL_DEVICE_ATOMIC_ORDER_ACQ_REL | CL_DEVICE_ATOMIC_ORDER_SEQ_CST |
+            CL_DEVICE_ATOMIC_SCOPE_WORK_ITEM | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP | CL_DEVICE_ATOMIC_SCOPE_DEVICE));
+
+        case CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: return RetValue((cl_bool)CL_FALSE);
+        case CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: return RetValue((cl_bool)CL_FALSE);
+        case CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: return RetValue((cl_bool)CL_FALSE);
+        case CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: return RetValue((cl_device_device_enqueue_capabilities)0);
+        case CL_DEVICE_PIPE_SUPPORT: return RetValue((cl_bool)CL_FALSE);
+
+        case CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: return RetValue((size_t)64);
+
+        case CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: return RetValue("");
         }
 
         return CL_INVALID_VALUE;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -128,8 +128,8 @@ clGetDeviceInfo(cl_device_id    device,
         case CL_DEVICE_IMAGE_MAX_BUFFER_SIZE: return ImageRetValueOrZero((size_t)(2 << D3D12_REQ_BUFFER_RESOURCE_TEXEL_COUNT_2_TO_EXP));
         case CL_DEVICE_IMAGE_MAX_ARRAY_SIZE: return ImageRetValueOrZero((size_t)D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION);
         case CL_DEVICE_MAX_SAMPLERS: return ImageRetValueOrZero((cl_uint)D3D12_COMMONSHADER_SAMPLER_SLOT_COUNT);
-        case CL_DEVICE_IMAGE_PITCH_ALIGNMENT: return ImageRetValueOrZero((size_t)D3D12_TEXTURE_DATA_PITCH_ALIGNMENT);
-        case CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: return RetValue((cl_uint)D3D12_TEXTURE_DATA_PLACEMENT_ALIGNMENT);
+        case CL_DEVICE_IMAGE_PITCH_ALIGNMENT: return ImageRetValueOrZero((cl_uint)0);
+        case CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: return RetValue((cl_uint)0);
 
         case CL_DEVICE_MAX_PARAMETER_SIZE: return RetValue((size_t)1024);
         case CL_DEVICE_MEM_BASE_ADDR_ALIGN: return RetValue((cl_uint)D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT * 8);
@@ -152,7 +152,7 @@ clGetDeviceInfo(cl_device_id    device,
         case CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE: return RetValue((cl_ulong)(D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT * 16));
         case CL_DEVICE_MAX_CONSTANT_ARGS: return RetValue((cl_uint)15);
 
-        case CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: return RetValue((size_t)65536);
+        case CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: return RetValue((size_t)0);
         case CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: return RetValue((size_t)0);
 
         case CL_DEVICE_LOCAL_MEM_TYPE: return RetValue((cl_device_local_mem_type)CL_LOCAL);
@@ -169,12 +169,11 @@ clGetDeviceInfo(cl_device_id    device,
 
         case CL_DEVICE_QUEUE_ON_HOST_PROPERTIES: return RetValue(
             (cl_command_queue_properties)(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_PROFILING_ENABLE));
-        case CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: return RetValue(
-            (cl_command_queue_properties)(CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE | CL_QUEUE_PROFILING_ENABLE));
-        case CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: return RetValue((cl_uint)(16 * 1024));
-        case CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: return RetValue((cl_uint)(256 * 1024));
-        case CL_DEVICE_MAX_ON_DEVICE_QUEUES: return RetValue((cl_uint)1);
-        case CL_DEVICE_MAX_ON_DEVICE_EVENTS: return RetValue(UINT_MAX);
+        case CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: return RetValue((cl_command_queue_properties)0);
+        case CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: return RetValue((cl_uint)0);
+        case CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: return RetValue((cl_uint)0);
+        case CL_DEVICE_MAX_ON_DEVICE_QUEUES: return RetValue((cl_uint)0);
+        case CL_DEVICE_MAX_ON_DEVICE_EVENTS: return RetValue((cl_uint)0);
 
         case CL_DEVICE_BUILT_IN_KERNELS: return RetValue("");
         case CL_DEVICE_PLATFORM: return RetValue(static_cast<cl_platform_id>(&pDevice->m_Parent.get()));

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -547,3 +547,25 @@ clReleaseDevice(cl_device_id device) CL_API_SUFFIX__VERSION_1_2
         return CL_INVALID_DEVICE;
     return CL_SUCCESS;
 }
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clCreateSubDevices(cl_device_id                         in_device,
+    const cl_device_partition_property * properties,
+    cl_uint                              num_devices,
+    cl_device_id *                       out_devices,
+    cl_uint *                            num_devices_ret) CL_API_SUFFIX__VERSION_1_2
+{
+    if (!in_device)
+    {
+        return CL_INVALID_DEVICE;
+    }
+    if (properties && properties[0] != 0)
+    {
+        // We don't support any of the partition modes, so the spec says we should return this
+        return CL_INVALID_VALUE;
+    }
+    UNREFERENCED_PARAMETER(num_devices);
+    UNREFERENCED_PARAMETER(out_devices);
+    UNREFERENCED_PARAMETER(num_devices_ret);
+    return CL_INVALID_DEVICE_PARTITION_COUNT;
+}

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -292,7 +292,7 @@ Kernel::Kernel(Program& Parent, std::string const& name, clc_dxil_object const* 
             CLAddressingModeFromSpirv(samplerMeta.addressing_mode),
             CLFilterModeFromSpirv(samplerMeta.filter_mode)
         };
-        m_ConstSamplers[i] = new Sampler(m_Parent->GetContext(), desc);
+        m_ConstSamplers[i] = new Sampler(m_Parent->GetContext(), desc, nullptr);
         m_Samplers[samplerMeta.sampler_id] = m_ConstSamplers[i].Get();
     }
 

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -462,6 +462,7 @@ clEnqueueNDRangeKernel(cl_command_queue command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception & e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
 
     return CL_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,6 +224,11 @@ cl_icd_dispatch g_DispatchTable
     /* OpenCL 2.2 */
     clSetProgramReleaseCallback,
     clSetProgramSpecializationConstant,
+
+    /* OpenCL 3.0 */
+    clCreateBufferWithProperties,
+    clCreateImageWithProperties,
+    clSetContextDestructorCallback,
 };
 
 Platform* g_Platform = nullptr;

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -35,6 +35,30 @@ clGetPlatformInfo(cl_platform_id   platform,
         }
         return CL_SUCCESS;
     }
+    else if (param_name == CL_PLATFORM_NUMERIC_VERSION)
+    {
+        return CopyOutParameter(
+#ifdef CLON12_SUPPORT_3_0
+            CL_MAKE_VERSION(3, 0, 0),
+#else
+            CL_MAKE_VERSION(1, 2, 0),
+#endif
+            param_value_size, param_value, param_value_size_ret);
+    }
+    else if (param_name == CL_PLATFORM_EXTENSIONS_WITH_VERSION)
+    {
+        constexpr cl_name_version extensions[] =
+        {
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_icd" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_extended_versioning" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_global_int32_base_atomics" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_global_int32_extended_atomics" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_local_int32_base_atomics" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_local_int32_extended_atomics" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_byte_addressable_store" },
+        };
+        return CopyOutParameter(extensions, param_value_size, param_value, param_value_size_ret);
+    }
 
     auto pPlatform = Platform::CastFrom(platform);
     auto pString = [pPlatform, param_name]() -> const char*

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -5,6 +5,8 @@
 #include "kernel.hpp"
 #include <dxc/dxcapi.h>
 
+#include <algorithm>
+
 struct ProgramBinaryHeader
 {
     static constexpr GUID c_ValidHeaderGuid = { /* 8d46c01e-2977-4234-a5b0-292405fc1d34 */
@@ -575,6 +577,7 @@ cl_int Program::Build(std::vector<Device::ref_ptr_int> Devices, const char* opti
 
     // Parse options
     BuildArgs Args = {};
+    AddBuiltinOptions(Devices, Args.Common);
     cl_int ret = ParseOptions(options, Args.Common, true, true);
     if (ret != CL_SUCCESS)
     {
@@ -668,6 +671,7 @@ cl_int Program::Compile(std::vector<Device::ref_ptr_int> Devices, const char* op
 
     // Parse options
     CompileArgs Args = {};
+    AddBuiltinOptions(Devices, Args.Common);
     cl_int ret = ParseOptions(options, Args.Common, true, false);
     if (ret != CL_SUCCESS)
     {
@@ -887,21 +891,42 @@ void Program::KernelFreed()
     --m_NumLiveKernels;
 }
 
+void Program::AddBuiltinOptions(std::vector<Device::ref_ptr_int> const& devices, CommonOptions& optionsStruct)
+{
+    optionsStruct.Args.reserve(15);
+#ifdef CLON12_SUPPORT_3_0
+    optionsStruct.Args.push_back("-D__OPENCL_VERSION__=300");
+#else
+    optionsStruct.Args.push_back("-D__OPENCL_VERSION__=120");
+#endif
+    // Disable extensions promoted to optional core features that we don't support
+    optionsStruct.Args.push_back("-cl-ext=-cl_khr_fp64");
+    optionsStruct.Args.push_back("-cl-ext=-cl_khr_depth_images");
+    optionsStruct.Args.push_back("-cl-ext=-cl_khr_subgroups");
+    // Disable optional core features that we don't support
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_fp64");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_device_enqueue");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_generic_address_space");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_pipes");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_program_scope_global_variables");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_subgroups");
+    optionsStruct.Args.push_back("-cl-ext=-__opencl_c_work_group_collective_functions");
+    // Query device caps to determine additional things to enable and/or disable
+    if (std::any_of(devices.begin(), devices.end(), [](Device::ref_ptr_int const& d) { return d->IsMCDM(); }))
+    {
+        optionsStruct.Args.push_back("-U__IMAGE_SUPPORT__");
+        optionsStruct.Args.push_back("-cl-ext=-__opencl_c_images");
+        optionsStruct.Args.push_back("-cl-ext=-__opencl_c_read_write_images");
+    }
+    else if (!std::all_of(devices.begin(), devices.end(), [](Device::ref_ptr_int const& d) { return d->SupportsTypedUAVLoad(); }))
+    {
+        optionsStruct.Args.push_back("-cl-ext=-__opencl_c_read_write_images");
+    }
+}
+
 cl_int Program::ParseOptions(const char* optionsStr, CommonOptions& optionsStruct, bool SupportCompilerOptions, bool SupportLinkerOptions)
 {
     using namespace std::string_view_literals;
-
-    if (SupportCompilerOptions)
-    {
-        optionsStruct.Args.push_back("-D__OPENCL_VERSION__=120");
-        optionsStruct.Args.push_back("-cl-ext=-cl_khr_fp64");
-        // TODO: Should we do a dual-compile if a context includes MCDM devices?
-        //if (m_Parent->GetDevice().IsMCDM())
-        //{
-        //    // Clang defines this by default for SPIR targets
-        //    optionsStruct.Args.push_back("-U__IMAGE_SUPPORT__");
-        //}
-    }
 
     std::string curOption;
     auto ValidateAndPushArg = [&]()
@@ -1072,6 +1097,7 @@ cl_int Program::BuildImpl(BuildArgs const& Args)
         clc_compile_args args = {};
 
         std::vector<const char*> raw_args;
+        raw_args.reserve(Args.Common.Args.size());
         for (auto& def : Args.Common.Args)
         {
             raw_args.push_back(def.c_str());
@@ -1159,11 +1185,13 @@ cl_int Program::CompileImpl(CompileArgs const& Args)
     clc_compile_args args = {};
 
     std::vector<const char*> raw_args;
+    raw_args.reserve(Args.Common.Args.size());
     for (auto& def : Args.Common.Args)
     {
         raw_args.push_back(def.c_str());
     }
     std::vector<clc_named_value> headers;
+    headers.reserve(Args.Headers.size());
     for (auto& h : Args.Headers)
     {
         headers.push_back(clc_named_value{ h.first.c_str(), h.second->m_Source.c_str() });

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -400,6 +400,7 @@ clGetProgramInfo(cl_program         program_,
                                     program.m_AssociatedDevices.size() * sizeof(program.m_AssociatedDevices[0]),
                                     param_value_size, param_value, param_value_size_ret);
     case CL_PROGRAM_SOURCE: return RetValue(program.m_Source.c_str());
+    case CL_PROGRAM_IL: return RetValue(nullptr);
     case CL_PROGRAM_BINARY_SIZES:
     {
         size_t OutSize = sizeof(size_t) * program.m_AssociatedDevices.size();
@@ -509,6 +510,8 @@ clGetProgramInfo(cl_program         program_,
         }
         return CL_INVALID_PROGRAM_EXECUTABLE;
     }
+    case CL_PROGRAM_SCOPE_GLOBAL_CTORS_PRESENT: return RetValue((cl_bool)CL_FALSE);
+    case CL_PROGRAM_SCOPE_GLOBAL_DTORS_PRESENT: return RetValue((cl_bool)CL_FALSE);
     }
 
     return program.GetContext().GetErrorReporter()("Unknown param_name", CL_INVALID_VALUE);
@@ -547,6 +550,7 @@ clGetProgramBuildInfo(cl_program            program_,
     case CL_PROGRAM_BUILD_OPTIONS: return RetValue(BuildData ? BuildData->m_LastBuildOptions.c_str() : "");
     case CL_PROGRAM_BUILD_LOG: return RetValue(BuildData ? BuildData->m_BuildLog.c_str() : "");
     case CL_PROGRAM_BINARY_TYPE: return RetValue(BuildData ? BuildData->m_BinaryType : CL_PROGRAM_BINARY_TYPE_NONE);
+    case CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE: return RetValue((size_t)0);
     }
 
     return program.GetContext().GetErrorReporter()("Unknown param_name", CL_INVALID_VALUE);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -222,34 +222,6 @@ clFinish(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
     return status;
 }
 
-extern CL_API_ENTRY cl_int CL_API_CALL
-clSetDefaultDeviceCommandQueue(cl_context           context_,
-    cl_device_id         device_,
-    cl_command_queue     command_queue) CL_API_SUFFIX__VERSION_2_1
-{
-    if (!context_)
-    {
-        return CL_INVALID_CONTEXT;
-    }
-    Context& context = *static_cast<Context*>(context_);
-    auto ReportError = context.GetErrorReporter();
-    if (!device_)
-    {
-        return ReportError("Device must not be null", CL_INVALID_DEVICE);
-    }
-    Device& device = *static_cast<Device*>(device_);
-    if (!context.ValidDeviceForContext(device))
-    {
-        return ReportError("Device not valid for this context", CL_INVALID_DEVICE);
-    }
-    if (!command_queue)
-    {
-        return ReportError("Queue must not be null", CL_INVALID_COMMAND_QUEUE);
-    }
-    // We don't support creating on-device queues so it's impossible to call this correctly
-    return ReportError("Queue is not an on-device queue", CL_INVALID_COMMAND_QUEUE);
-}
-
 static bool IsOutOfOrder(const cl_queue_properties* properties)
 {
     auto prop = FindProperty<cl_queue_properties>(properties, CL_QUEUE_PROPERTIES);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -209,6 +209,34 @@ clFinish(cl_command_queue command_queue) CL_API_SUFFIX__VERSION_1_0
     return status;
 }
 
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetDefaultDeviceCommandQueue(cl_context           context_,
+    cl_device_id         device_,
+    cl_command_queue     command_queue) CL_API_SUFFIX__VERSION_2_1
+{
+    if (!context_)
+    {
+        return CL_INVALID_CONTEXT;
+    }
+    Context& context = *static_cast<Context*>(context_);
+    auto ReportError = context.GetErrorReporter();
+    if (!device_)
+    {
+        return ReportError("Device must not be null", CL_INVALID_DEVICE);
+    }
+    Device& device = *static_cast<Device*>(device_);
+    if (!context.ValidDeviceForContext(device))
+    {
+        return ReportError("Device not valid for this context", CL_INVALID_DEVICE);
+    }
+    if (!command_queue)
+    {
+        return ReportError("Queue must not be null", CL_INVALID_COMMAND_QUEUE);
+    }
+    // We don't support creating on-device queues so it's impossible to call this correctly
+    return ReportError("Queue is not an on-device queue", CL_INVALID_COMMAND_QUEUE);
+}
+
 static bool IsOutOfOrder(const cl_queue_properties* properties)
 {
     auto prop = FindProperty<cl_queue_properties>(properties, CL_QUEUE_PROPERTIES);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -32,11 +32,12 @@ bool ValidateQueueProperties(cl_queue_properties const* properties, TReporter&& 
     return true;
 }
 
-extern CL_API_ENTRY cl_command_queue CL_API_CALL
-clCreateCommandQueueWithProperties(cl_context               context_,
+static cl_command_queue
+clCreateCommandQueueWithPropertiesImpl(cl_context               context_,
     cl_device_id             device_,
     const cl_queue_properties *    properties,
-    cl_int *                 errcode_ret) CL_API_SUFFIX__VERSION_2_0
+    cl_int *                 errcode_ret,
+    bool synthesized_properties)
 {
     if (!context_)
     {
@@ -76,11 +77,20 @@ clCreateCommandQueueWithProperties(cl_context               context_,
     try
     {
         if (errcode_ret) *errcode_ret = CL_SUCCESS;
-        return new CommandQueue(device, context, properties);
+        return new CommandQueue(device, context, properties, synthesized_properties);
     }
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error &) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+}
+
+extern CL_API_ENTRY cl_command_queue CL_API_CALL
+clCreateCommandQueueWithProperties(cl_context               context,
+    cl_device_id             device,
+    const cl_queue_properties *    properties,
+    cl_int *                 errcode_ret) CL_API_SUFFIX__VERSION_2_0
+{
+    return clCreateCommandQueueWithPropertiesImpl(context, device, properties, errcode_ret, false);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -121,6 +131,7 @@ clGetCommandQueueInfo(cl_command_queue      command_queue,
     {
         return CopyOutParameter(param, param_value_size, param_value, param_value_size_ret);
     };
+    auto ReportError = queue.GetContext().GetErrorReporter();
 
     switch (param_name)
     {
@@ -129,15 +140,17 @@ clGetCommandQueueInfo(cl_command_queue      command_queue,
     case CL_QUEUE_REFERENCE_COUNT: return RetValue((cl_uint)queue.GetRefCount());
     case CL_QUEUE_PROPERTIES: 
         return RetValue(*FindProperty<cl_queue_properties>(queue.m_Properties.data(), CL_QUEUE_PROPERTIES));
-        /* TODO: OpenCL 3.0
     case CL_QUEUE_PROPERTIES_ARRAY:
+        if (queue.m_bPropertiesSynthesized)
+            return RetValue(nullptr);
         return CopyOutParameterImpl(queue.m_Properties.data(),
             queue.m_Properties.size() * sizeof(queue.m_Properties[0]),
             param_value_size, param_value, param_value_size_ret);
-        */
+    case CL_QUEUE_SIZE: return ReportError("Queue is not a device queue", CL_INVALID_COMMAND_QUEUE);
+    case CL_QUEUE_DEVICE_DEFAULT: return RetValue((cl_command_queue)nullptr);
     }
 
-    return queue.GetContext().GetErrorReporter()("Unknown param_name", CL_INVALID_VALUE);
+    return ReportError("Unknown param_name", CL_INVALID_VALUE);
 }
 
 /*
@@ -173,7 +186,7 @@ clCreateCommandQueue(cl_context                     context,
     cl_int *                       errcode_ret) CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
 {
     cl_queue_properties PropArray[3] = { CL_QUEUE_PROPERTIES, properties, 0 };
-    return clCreateCommandQueueWithProperties(context, device, PropArray, errcode_ret);
+    return clCreateCommandQueueWithPropertiesImpl(context, device, PropArray, errcode_ret, true);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -247,12 +260,13 @@ static bool IsProfile(const cl_queue_properties* properties)
     auto prop = FindProperty<cl_queue_properties>(properties, CL_QUEUE_PROPERTIES);
     return prop != nullptr && ((*prop) & CL_QUEUE_PROFILING_ENABLE) != 0;
 }
-CommandQueue::CommandQueue(Device& device, Context& context, const cl_queue_properties* properties)
+CommandQueue::CommandQueue(Device& device, Context& context, const cl_queue_properties* properties, bool synthesizedProperties)
     : CLChildBase(device)
     , m_Context(context)
     , m_Properties(PropertiesToVector(properties))
     , m_bOutOfOrder(IsOutOfOrder(properties))
     , m_bProfile(IsProfile(properties))
+    , m_bPropertiesSynthesized(synthesizedProperties)
 {
 }
 

--- a/src/resource_migrate.cpp
+++ b/src/resource_migrate.cpp
@@ -251,7 +251,6 @@ clEnqueueMigrateMemObjects(cl_command_queue       command_queue,
         return ReportError("Must supply mem_objects.", CL_INVALID_VALUE);
     }
 
-    // TODO validate context
     // TODO validate flags
 
     try
@@ -270,5 +269,6 @@ clEnqueueMigrateMemObjects(cl_command_queue       command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }

--- a/src/resource_tasks.cpp
+++ b/src/resource_tasks.cpp
@@ -406,6 +406,7 @@ cl_int clEnqueueWriteBufferRectImpl(cl_command_queue    command_queue,
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -571,6 +572,7 @@ clEnqueueFillBuffer(cl_command_queue   command_queue,
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -667,6 +669,7 @@ clEnqueueWriteImage(cl_command_queue    command_queue,
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -850,6 +853,7 @@ clEnqueueFillImage(cl_command_queue   command_queue,
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -1149,6 +1153,7 @@ cl_int clEnqueueReadBufferRectImpl(cl_command_queue    command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception & e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return ret;
 }
 
@@ -1322,6 +1327,7 @@ clEnqueueReadImage(cl_command_queue     command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception & e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return ret;
 }
 
@@ -1546,6 +1552,7 @@ clEnqueueCopyBuffer(cl_command_queue    command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -1645,6 +1652,7 @@ clEnqueueCopyImage(cl_command_queue     command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -1971,6 +1979,7 @@ clEnqueueCopyBufferRect(cl_command_queue    command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -2232,6 +2241,7 @@ clEnqueueCopyImageToBuffer(cl_command_queue command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -2318,6 +2328,7 @@ clEnqueueCopyBufferToImage(cl_command_queue command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 
@@ -2682,6 +2693,7 @@ clEnqueueMapBuffer(cl_command_queue command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
 }
 
 extern CL_API_ENTRY void * CL_API_CALL
@@ -2814,6 +2826,7 @@ clEnqueueMapImage(cl_command_queue  command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
 }
 
 class UnmapTask : public Task
@@ -2893,6 +2906,7 @@ clEnqueueUnmapMemObject(cl_command_queue command_queue,
     catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
     return CL_SUCCESS;
 }
 

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -135,11 +135,12 @@ bool ValidateMemFlagsForBufferReference(cl_mem_flags& flags, Resource& buffer, T
 
 /* Memory Object APIs */
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateBuffer(cl_context   context_,
+clCreateBufferWithProperties(cl_context   context_,
+    const cl_mem_properties* properties,
     cl_mem_flags flags,
     size_t       size,
     void *       host_ptr,
-    cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0
+    cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_3_0
 {
     if (!context_)
     {
@@ -148,6 +149,10 @@ clCreateBuffer(cl_context   context_,
     }
     Context& context = *static_cast<Context*>(context_);
     auto ReportError = context.GetErrorReporter(errcode_ret);
+    if (properties && properties[0] != 0)
+    {
+        return ReportError("Invalid properties specified", CL_INVALID_PROPERTY);
+    }
 
     if (size == 0 || size > UINT_MAX)
     {
@@ -197,6 +202,16 @@ clCreateBuffer(cl_context   context_,
 }
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateBuffer(cl_context   context,
+    cl_mem_flags flags,
+    size_t       size,
+    void *       host_ptr,
+    cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0
+{
+    return clCreateBufferWithProperties(context, nullptr, flags, size, host_ptr, errcode_ret);
+}
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
 clCreateSubBuffer(cl_mem                   buffer_,
     cl_mem_flags             flags,
     cl_buffer_create_type    buffer_create_type,
@@ -238,12 +253,13 @@ clCreateSubBuffer(cl_mem                   buffer_,
 }
 
 extern CL_API_ENTRY cl_mem CL_API_CALL
-clCreateImage(cl_context              context_,
+clCreateImageWithProperties(cl_context              context_,
+    const cl_mem_properties* properties,
     cl_mem_flags            flags,
     const cl_image_format * image_format,
     const cl_image_desc *   image_desc,
     void *                  host_ptr,
-    cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_1_2
+    cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_3_0
 {
     if (!context_)
     {
@@ -252,6 +268,11 @@ clCreateImage(cl_context              context_,
     }
     Context& context = *static_cast<Context*>(context_);
     auto ReportError = context.GetErrorReporter(errcode_ret);
+
+    if (properties && properties[0] != 0)
+    {
+        return ReportError("Invalid properties", CL_INVALID_PROPERTY);
+    }
 
     if (!ValidateMemFlags(flags, host_ptr != nullptr, ReportError))
     {
@@ -462,6 +483,17 @@ clCreateImage(cl_context              context_,
     {
         return ReportError(e.what(), CL_OUT_OF_RESOURCES);
     }
+}
+
+extern CL_API_ENTRY cl_mem CL_API_CALL
+clCreateImage(cl_context              context,
+    cl_mem_flags            flags,
+    const cl_image_format * image_format,
+    const cl_image_desc *   image_desc,
+    void *                  host_ptr,
+    cl_int *                errcode_ret) CL_API_SUFFIX__VERSION_1_2
+{
+    return clCreateImageWithProperties(context, nullptr, flags, image_format, image_desc, host_ptr, errcode_ret);
 }
 
 extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_1_1_DEPRECATED cl_mem CL_API_CALL

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -618,10 +618,14 @@ clGetSupportedImageFormats(cl_context           context_,
                     return false;
                 }
 
-                // OpenCL 1.2 doesn't require a single kernel to be able to read and write images, so we can bind
-                // readable images as SRVs and only require sample support, rather than typed UAV load.
                 if ((flags & (CL_MEM_READ_ONLY | CL_MEM_READ_WRITE)) &&
                     (Support.Support1 & D3D12_FORMAT_SUPPORT1_SHADER_LOAD) == D3D12_FORMAT_SUPPORT1_NONE)
+                {
+                    return false;
+                }
+
+                if ((flags & CL_MEM_KERNEL_READ_AND_WRITE) &&
+                    (Support.Support2 & D3D12_FORMAT_SUPPORT2_UAV_TYPED_LOAD) == D3D12_FORMAT_SUPPORT2_NONE)
                 {
                     return false;
                 }

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -709,6 +709,8 @@ clGetMemObjectInfo(cl_mem           memobj,
     case CL_MEM_CONTEXT: return RetValue(&resource.m_Parent.get());
     case CL_MEM_ASSOCIATED_MEMOBJECT: return RetValue(resource.m_ParentBuffer.Get());
     case CL_MEM_OFFSET: return RetValue(resource.m_Offset);
+    case CL_MEM_USES_SVM_POINTER: return RetValue((bool)CL_FALSE);
+    case CL_MEM_PROPERTIES: return RetValue(nullptr);
     }
     return resource.m_Parent->GetErrorReporter()("Unknown param_name", CL_INVALID_VALUE);
 }

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -30,9 +30,10 @@ static D3D12_SAMPLER_DESC TranslateSamplerDesc(Sampler::Desc const& desc)
     return ret;
 }
 
-Sampler::Sampler(Context& Parent, Desc const& desc)
+Sampler::Sampler(Context& Parent, Desc const& desc, const cl_sampler_properties *properties)
     : CLChildBase(Parent)
     , m_Desc(desc)
+    , m_Properties(PropertiesToVector(properties))
 {
 }
 
@@ -79,6 +80,50 @@ bool ValidateSamplerProperties(cl_sampler_properties const* properties, TReporte
     return true;
 }
 
+static cl_sampler
+clCreateSamplerWithPropertiesImpl(cl_context                     context_,
+    const cl_sampler_properties *  sampler_properties,
+    Sampler::Desc &                desc,
+    cl_int *                       errcode_ret)
+{
+    if (!context_)
+    {
+        if (errcode_ret) *errcode_ret = CL_INVALID_CONTEXT;
+        return nullptr;
+    }
+    Context& context = *static_cast<Context*>(context_);
+    auto ReportError = context.GetErrorReporter(errcode_ret);
+
+    if (desc.NormalizedCoords > 1)
+        desc.NormalizedCoords = 1;
+    switch (desc.AddressingMode)
+    {
+    case CL_ADDRESS_NONE:
+    case CL_ADDRESS_CLAMP_TO_EDGE:
+    case CL_ADDRESS_CLAMP:
+    case CL_ADDRESS_REPEAT:
+    case CL_ADDRESS_MIRRORED_REPEAT:
+        break;
+    default: return ReportError("Invalid sampler addressing mode.", CL_INVALID_VALUE);
+    }
+    switch (desc.FilterMode)
+    {
+    case CL_FILTER_LINEAR:
+    case CL_FILTER_NEAREST:
+        break;
+    default: return ReportError("Invalid sampler filter mode.", CL_INVALID_VALUE);
+    }
+
+    try
+    {
+        if (errcode_ret) *errcode_ret = CL_SUCCESS;
+        return new Sampler(context, desc, sampler_properties);
+    }
+    catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
+    catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
+    catch (_com_error &) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+}
+
 CL_API_ENTRY cl_sampler CL_API_CALL
 clCreateSamplerWithProperties(cl_context                     context_,
     const cl_sampler_properties *  sampler_properties,
@@ -105,53 +150,18 @@ clCreateSamplerWithProperties(cl_context                     context_,
     if (auto FoundVal = FindProperty<cl_sampler_properties>(sampler_properties, CL_SAMPLER_FILTER_MODE); FoundVal)
         desc.FilterMode = (cl_filter_mode)*FoundVal;
 
-    return clCreateSampler(context_, desc.NormalizedCoords, desc.AddressingMode, desc.FilterMode, errcode_ret);
+    return clCreateSamplerWithPropertiesImpl(context_, sampler_properties, desc, errcode_ret);
 }
 
 CL_API_ENTRY CL_EXT_PREFIX__VERSION_1_2_DEPRECATED cl_sampler CL_API_CALL
-clCreateSampler(cl_context          context_,
+clCreateSampler(cl_context          context,
     cl_bool             normalized_coords,
     cl_addressing_mode  addressing_mode,
     cl_filter_mode      filter_mode,
     cl_int *            errcode_ret) CL_EXT_SUFFIX__VERSION_1_2_DEPRECATED
 {
-    if (!context_)
-    {
-        if (errcode_ret) *errcode_ret = CL_INVALID_CONTEXT;
-        return nullptr;
-    }
-    Context& context = *static_cast<Context*>(context_);
-    auto ReportError = context.GetErrorReporter(errcode_ret);
-
     Sampler::Desc desc = { normalized_coords, addressing_mode, filter_mode };
-    if (desc.NormalizedCoords > 1)
-        desc.NormalizedCoords = 1;
-    switch (desc.AddressingMode)
-    {
-    case CL_ADDRESS_NONE:
-    case CL_ADDRESS_CLAMP_TO_EDGE:
-    case CL_ADDRESS_CLAMP:
-    case CL_ADDRESS_REPEAT:
-    case CL_ADDRESS_MIRRORED_REPEAT:
-        break;
-    default: return ReportError("Invalid sampler addressing mode.", CL_INVALID_VALUE);
-    }
-    switch (desc.FilterMode)
-    {
-    case CL_FILTER_LINEAR:
-    case CL_FILTER_NEAREST:
-        break;
-    default: return ReportError("Invalid sampler filter mode.", CL_INVALID_VALUE);
-    }
-
-    try
-    {
-        if (errcode_ret) *errcode_ret = CL_SUCCESS;
-        return new Sampler(context, desc);
-    }
-    catch (std::bad_alloc&) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
-    catch (std::exception& e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
-    catch (_com_error &) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    return clCreateSamplerWithPropertiesImpl(context, nullptr, desc, errcode_ret);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL
@@ -196,6 +206,10 @@ clGetSamplerInfo(cl_sampler         sampler_,
     case CL_SAMPLER_NORMALIZED_COORDS: return RetValue(desc.NormalizedCoords);
     case CL_SAMPLER_ADDRESSING_MODE: return RetValue(desc.AddressingMode);
     case CL_SAMPLER_FILTER_MODE: return RetValue(desc.FilterMode);
+    case CL_SAMPLER_PROPERTIES:
+        return CopyOutParameterImpl(sampler.m_Properties.data(),
+            sampler.m_Properties.size() * sizeof(sampler.m_Properties[0]),
+            param_value_size, param_value, param_value_size_ret);
     }
     return sampler.m_Parent->GetErrorReporter()("Unknown param_name", CL_INVALID_VALUE);
 }

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -16,21 +16,6 @@ clSetDefaultDeviceCommandQueue(cl_context           context,
     return CL_INVALID_PLATFORM;
 }
 
-extern CL_API_ENTRY cl_int CL_API_CALL
-clGetDeviceAndHostTimer(cl_device_id    device,
-    cl_ulong*       device_timestamp,
-    cl_ulong*       host_timestamp) CL_API_SUFFIX__VERSION_2_1
-{
-    return CL_INVALID_PLATFORM;
-}
-
-extern CL_API_ENTRY cl_int CL_API_CALL
-clGetHostTimer(cl_device_id device,
-    cl_ulong *   host_timestamp) CL_API_SUFFIX__VERSION_2_1
-{
-    return CL_INVALID_PLATFORM;
-}
-
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_mem CL_API_CALL

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -8,14 +8,6 @@
 
 #pragma warning(disable: 4100)
 
-extern CL_API_ENTRY cl_int CL_API_CALL
-clSetDefaultDeviceCommandQueue(cl_context           context,
-    cl_device_id         device,
-    cl_command_queue     command_queue) CL_API_SUFFIX__VERSION_2_1
-{
-    return CL_INVALID_PLATFORM;
-}
-
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_mem CL_API_CALL

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -9,16 +9,6 @@
 #pragma warning(disable: 4100)
 
 extern CL_API_ENTRY cl_int CL_API_CALL
-clCreateSubDevices(cl_device_id                         in_device,
-    const cl_device_partition_property * properties,
-    cl_uint                              num_devices,
-    cl_device_id *                       out_devices,
-    cl_uint *                            num_devices_ret) CL_API_SUFFIX__VERSION_1_2
-{
-    return CL_INVALID_DEVICE_PARTITION_COUNT;
-}
-
-extern CL_API_ENTRY cl_int CL_API_CALL
 clSetDefaultDeviceCommandQueue(cl_context           context,
     cl_device_id         device,
     cl_command_queue     command_queue) CL_API_SUFFIX__VERSION_2_1

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "context.hpp"
+#include "queue.hpp"
 #include "program.hpp"
+#include "kernel.hpp"
 
 #pragma warning(disable: 4100)
 
@@ -185,14 +187,16 @@ clSetProgramSpecializationConstant(cl_program  program,
     return context.GetErrorReporter()("This platform does not yet support SPIR-V programs", CL_INVALID_OPERATION);
 }
 
-#ifdef CL_VERSION_2_0
-
 extern CL_API_ENTRY cl_int CL_API_CALL
 clSetKernelArgSVMPointer(cl_kernel    kernel,
     cl_uint      arg_index,
     const void * arg_value) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!kernel)
+    {
+        return CL_INVALID_KERNEL;
+    }
+    return static_cast<Kernel*>(kernel)->m_Parent->m_Parent->GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -201,12 +205,12 @@ clSetKernelExecInfo(cl_kernel            kernel,
     size_t               param_value_size,
     const void *         param_value) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!kernel)
+    {
+        return CL_INVALID_KERNEL;
+    }
+    return static_cast<Kernel*>(kernel)->m_Parent->m_Parent->GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
-
-#endif
-
-#ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clGetKernelSubGroupInfo(cl_kernel                   kernel,
@@ -218,10 +222,12 @@ clGetKernelSubGroupInfo(cl_kernel                   kernel,
     void*                       param_value,
     size_t*                     param_value_size_ret) CL_API_SUFFIX__VERSION_2_1
 {
-    return CL_INVALID_PLATFORM;
+    if (!kernel)
+    {
+        return CL_INVALID_KERNEL;
+    }
+    return static_cast<Kernel*>(kernel)->m_Parent->m_Parent->GetErrorReporter()("Platform does not support subgroups", CL_INVALID_OPERATION);
 }
-
-#endif
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueNativeKernel(cl_command_queue  command_queue,
@@ -235,10 +241,12 @@ clEnqueueNativeKernel(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_1_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support native kernels", CL_INVALID_OPERATION);
 }
-
-#ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueSVMFree(cl_command_queue  command_queue,
@@ -253,7 +261,11 @@ clEnqueueSVMFree(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -266,7 +278,11 @@ clEnqueueSVMMemcpy(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -279,7 +295,11 @@ clEnqueueSVMMemFill(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -292,7 +312,11 @@ clEnqueueSVMMap(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -302,12 +326,12 @@ clEnqueueSVMUnmap(cl_command_queue  command_queue,
     const cl_event *  event_wait_list,
     cl_event *        event) CL_API_SUFFIX__VERSION_2_0
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
-
-#endif
-
-#ifdef CL_VERSION_2_1
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueSVMMigrateMem(cl_command_queue         command_queue,
@@ -319,12 +343,12 @@ clEnqueueSVMMigrateMem(cl_command_queue         command_queue,
     const cl_event *         event_wait_list,
     cl_event *               event) CL_API_SUFFIX__VERSION_2_1
 {
-    return CL_INVALID_PLATFORM;
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
-
-#endif
-
-#ifdef CL_VERSION_1_2
 
 /* Extension function access
  *
@@ -340,13 +364,11 @@ clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
     return nullptr;
 }
 
-#endif
-
 /* Deprecated OpenCL 1.1 APIs */
 
 extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL
 clUnloadCompiler(void) CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
 {
-    return CL_INVALID_PLATFORM;
+    return CL_SUCCESS;
 }
 

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -185,18 +185,6 @@ clSetProgramSpecializationConstant(cl_program  program,
     return context.GetErrorReporter()("This platform does not yet support SPIR-V programs", CL_INVALID_OPERATION);
 }
 
-#ifdef CL_VERSION_2_1
-
-extern CL_API_ENTRY cl_kernel CL_API_CALL
-clCloneKernel(cl_kernel     source_kernel,
-    cl_int*       errcode_ret) CL_API_SUFFIX__VERSION_2_1
-{
-    *errcode_ret = CL_INVALID_PLATFORM;
-    return nullptr;
-}
-
-#endif
-
 #ifdef CL_VERSION_2_0
 
 extern CL_API_ENTRY cl_int CL_API_CALL

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "context.hpp"
+#include "program.hpp"
 
 #pragma warning(disable: 4100)
 
@@ -156,15 +157,18 @@ clCreateProgramWithIL(cl_context    context_,
     return ReportError("Platform does not yet support IL programs", CL_INVALID_OPERATION);
 }
 
-#ifdef CL_VERSION_2_2
-
-extern CL_API_ENTRY cl_int CL_API_CALL
+extern CL_API_ENTRY CL_EXT_PREFIX__VERSION_2_2_DEPRECATED cl_int CL_API_CALL
 clSetProgramReleaseCallback(cl_program          program,
     void (CL_CALLBACK * pfn_notify)(cl_program program,
         void * user_data),
-    void *              user_data) CL_API_SUFFIX__VERSION_2_2
+    void *              user_data) CL_EXT_SUFFIX__VERSION_2_2_DEPRECATED
 {
-    return CL_INVALID_PLATFORM;
+    if (!program)
+    {
+        return CL_INVALID_PROGRAM;
+    }
+    Context& context = static_cast<Program*>(program)->m_Parent.get();
+    return context.GetErrorReporter()("This platform does not support global program destructors", CL_INVALID_OPERATION);
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -173,10 +177,13 @@ clSetProgramSpecializationConstant(cl_program  program,
     size_t      spec_size,
     const void* spec_value) CL_API_SUFFIX__VERSION_2_2
 {
-    return CL_INVALID_PLATFORM;
+    if (!program)
+    {
+        return CL_INVALID_PROGRAM;
+    }
+    Context& context = static_cast<Program*>(program)->m_Parent.get();
+    return context.GetErrorReporter()("This platform does not yet support SPIR-V programs", CL_INVALID_OPERATION);
 }
-
-#endif
 
 #ifdef CL_VERSION_2_1
 


### PR DESCRIPTION
This PR implements the entirety of the CL3.0 API surface area (the 3 new functions, all the new info queries, plus the required 2.x functions like `clCloneKernel`). Everything optional here is disabled *except* for read-write images, which are hooked up, but requires a compiler with [some changes](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/10163) to actually work.

The new code is very poorly tested, but does pass the `test_basic` readwrite image test.

There's one missing required(?) feature that I haven't hooked up yet, which is creating an image from an image, for the purpose of format casting. Should be easy enough.

Optional features and extensions that I'd like to start implementing after this:
* Generic pointers are largely already supported by our compiler thanks to Intel raytracing kernels needing them.
* Global program-scope variables are pretty close to supported in the compiler as well.
* SPIR and SPIR-V are already part of our compilation pipeline, so it should be easy enough to start the compilation further along that pipeline.
* Mipmaps are easy enough, but probably aren't useful until there's interop with D3D/GL, which is where "easy" stops.