### PR TITLE
Cl/GL interop extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,12 @@ target_include_directories(openclon12
     PRIVATE include
     PRIVATE external
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(openclon12 d3d12translationlayer OpenCL::Headers WIL)
+target_link_libraries(openclon12
+    d3d12translationlayer
+    OpenCL::Headers
+    WIL
+    user32
+    gdi32)
 source_group("Header Files\\External" FILES ${EXTERNAL_INC})
 
 option(BUILD_TESTS "Build tests" ON)

--- a/external/d3d12_interop_public.h
+++ b/external/d3d12_interop_public.h
@@ -1,0 +1,52 @@
+/*
+* Copyright © Microsoft Corporation
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice (including the next
+* paragraph) shall be included in all copies or substantial portions of the
+* Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
+#include <stdint.h>
+
+#ifndef D3D12_INTEROP_PUBLIC_H
+#define D3D12_INTEROP_PUBLIC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ID3D12Device;
+struct ID3D12CommandQueue;
+struct ID3D12Resource;
+
+struct d3d12_interop_device_info {
+   uint64_t adapter_luid;
+   ID3D12Device *device;
+   ID3D12CommandQueue *queue;
+};
+
+struct d3d12_interop_resource_info {
+   ID3D12Resource *resource;
+   uint64_t buffer_offset;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* D3D12_INTEROP_PUBLIC_H */

--- a/external/mesa_glinterop.h
+++ b/external/mesa_glinterop.h
@@ -297,7 +297,7 @@ MesaGLInteropEGLQueryDeviceInfo(EGLDisplay dpy, EGLContext context,
 * and HGLRC.
 */
 int
-MesaGLInteropWGLQueryDeviceInfo(HDC dpy, HGLRC context,
+wglMesaGLInteropQueryDeviceInfo(HDC dpy, HGLRC context,
                                 struct mesa_glinterop_device_info *out);
 
 /**
@@ -332,7 +332,7 @@ MesaGLInteropEGLExportObject(EGLDisplay dpy, EGLContext context,
 * HDC and HGLRC.
 */
 int
-MesaGLInteropWGLExportObject(HDC dpy, HGLRC context,
+wglMesaGLInteropExportObject(HDC dpy, HGLRC context,
                              struct mesa_glinterop_export_in *in,
                              struct mesa_glinterop_export_out *out);
 
@@ -367,7 +367,7 @@ MesaGLInteropEGLFlushObjects(EGLDisplay dpy, EGLContext context,
 * HDC and HGLRC.
 */
 int
-MesaGLInteropWGLFlushObjects(HDC dpy, HGLRC context,
+wglMesaGLInteropFlushObjects(HDC dpy, HGLRC context,
                              unsigned count, struct mesa_glinterop_export_in *resources,
                              GLsync *sync);
 
@@ -376,7 +376,7 @@ typedef int (PFNMESAGLINTEROPGLXQUERYDEVICEINFOPROC)(struct _XDisplay *dpy, stru
                                                      struct mesa_glinterop_device_info *out);
 typedef int (PFNMESAGLINTEROPEGLQUERYDEVICEINFOPROC)(EGLDisplay dpy, EGLContext context,
                                                      struct mesa_glinterop_device_info *out);
-typedef int (PFNMESAGLINTEROPWGLQUERYDEVICEINFOPROC)(HDC dpy, HGLRC context,
+typedef int (PFNWGLMESAGLINTEROPQUERYDEVICEINFOPROC)(HDC dpy, HGLRC context,
                                                      struct mesa_glinterop_device_info *out);
 typedef int (PFNMESAGLINTEROPGLXEXPORTOBJECTPROC)(struct _XDisplay *dpy, struct __GLXcontextRec *context,
                                                   struct mesa_glinterop_export_in *in,
@@ -384,7 +384,7 @@ typedef int (PFNMESAGLINTEROPGLXEXPORTOBJECTPROC)(struct _XDisplay *dpy, struct 
 typedef int (PFNMESAGLINTEROPEGLEXPORTOBJECTPROC)(EGLDisplay dpy, EGLContext context,
                                                   struct mesa_glinterop_export_in *in,
                                                   struct mesa_glinterop_export_out *out);
-typedef int (PFNMESAGLINTEROPWGLEXPORTOBJECTPROC)(HDC dpy, HGLRC context,
+typedef int (PFNWGLMESAGLINTEROPEXPORTOBJECTPROC)(HDC dpy, HGLRC context,
                                                   struct mesa_glinterop_export_in *in,
                                                   struct mesa_glinterop_export_out *out);
 typedef int (PFNMESAGLINTEROPGLXFLUSHOBJECTSPROC)(struct _XDisplay *dpy, struct __GLXcontextRec *context,
@@ -393,7 +393,7 @@ typedef int (PFNMESAGLINTEROPGLXFLUSHOBJECTSPROC)(struct _XDisplay *dpy, struct 
 typedef int (PFNMESAGLINTEROPEGLFLUSHOBJECTSPROC)(EGLDisplay dpy, EGLContext context,
                                                   unsigned count, struct mesa_glinterop_export_in *resources,
                                                   GLsync *sync);
-typedef int (PFNMESAGLINTEROPWGLFLUSHOBJECTSPROC)(HDC dpy, HGLRC context,
+typedef int (PFNWGLMESAGLINTEROPFLUSHOBJECTSPROC)(HDC dpy, HGLRC context,
                                                   unsigned count, struct mesa_glinterop_export_in *resources,
                                                   GLsync *sync);
 

--- a/external/mesa_glinterop.h
+++ b/external/mesa_glinterop.h
@@ -1,0 +1,404 @@
+/*
+ * Mesa 3-D graphics library
+ *
+ * Copyright 2016 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Mesa OpenGL inter-driver interoperability interface designed for but not
+ * limited to OpenCL.
+ *
+ * This is a driver-agnostic, backward-compatible interface. The structures
+ * are only allowed to grow. They can never shrink and their members can
+ * never be removed, renamed, or redefined.
+ *
+ * The interface doesn't return a lot of static texture parameters like
+ * width, height, etc. It mainly returns mutable buffer and texture view
+ * parameters that can't be part of the texture allocation (because they are
+ * mutable). If drivers want to return more data or want to return static
+ * allocation parameters, they can do it in one of these two ways:
+ * - attaching the data to the DMABUF handle in a driver-specific way
+ * - passing the data via "out_driver_data" in the "in" structure.
+ *
+ * Mesa is expected to do a lot of error checking on behalf of OpenCL, such
+ * as checking the target, miplevel, and texture completeness.
+ *
+ * OpenCL, on the other hand, needs to check if the display+context combo
+ * is compatible with the OpenCL driver by querying the device information.
+ * It also needs to check if the texture internal format and channel ordering
+ * (returned in a driver-specific way) is supported by OpenCL, among other
+ * things.
+ */
+
+#ifndef MESA_GLINTEROP_H
+#define MESA_GLINTEROP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declarations to avoid inclusion of GL/glx.h */
+#ifndef GLX_H
+struct _XDisplay;
+struct __GLXcontextRec;
+#endif
+
+/* Forward declarations to avoid inclusion of EGL/egl.h */
+#ifndef __egl_h_
+typedef void *EGLDisplay;
+typedef void *EGLContext;
+#endif
+
+#ifndef _WINDEF_
+struct HDC__;
+typedef struct HDC__ *HDC;
+struct HGLRC__;
+typedef struct HGLRC__ *HGLRC;
+typedef void *HANDLE;
+#endif
+
+typedef struct __GLsync *GLsync;
+
+/** Returned error codes. */
+enum {
+   MESA_GLINTEROP_SUCCESS = 0,
+   MESA_GLINTEROP_OUT_OF_RESOURCES,
+   MESA_GLINTEROP_OUT_OF_HOST_MEMORY,
+   MESA_GLINTEROP_INVALID_OPERATION,
+   MESA_GLINTEROP_INVALID_VERSION,
+   MESA_GLINTEROP_INVALID_DISPLAY,
+   MESA_GLINTEROP_INVALID_CONTEXT,
+   MESA_GLINTEROP_INVALID_TARGET,
+   MESA_GLINTEROP_INVALID_OBJECT,
+   MESA_GLINTEROP_INVALID_MIP_LEVEL,
+   MESA_GLINTEROP_UNSUPPORTED
+};
+
+/** Access flags. */
+enum {
+   MESA_GLINTEROP_ACCESS_READ_WRITE = 0,
+   MESA_GLINTEROP_ACCESS_READ_ONLY,
+   MESA_GLINTEROP_ACCESS_WRITE_ONLY
+};
+
+#define MESA_GLINTEROP_DEVICE_INFO_VERSION 2
+
+/**
+ * Device information returned by Mesa.
+ */
+struct mesa_glinterop_device_info {
+   /* The caller should set this to the version of the struct they support */
+   /* The callee will overwrite it if it supports a lower version.
+    *
+    * The caller should check the value and access up-to the version supported
+    * by the callee.
+    */
+   /* NOTE: Do not use the MESA_GLINTEROP_DEVICE_INFO_VERSION macro */
+   uint32_t version;
+
+   /* PCI location */
+   uint32_t pci_segment_group;
+   uint32_t pci_bus;
+   uint32_t pci_device;
+   uint32_t pci_function;
+
+   /* Device identification */
+   uint32_t vendor_id;
+   uint32_t device_id;
+
+   /* Structure version 1 ends here. */
+
+   /* Size of memory pointed to by out_driver_data. */
+   uint32_t driver_data_size;
+
+   /* If the caller wants to query driver-specific data about the OpenGL
+   * object, this should point to the memory where that data will be stored.
+   * This is expected to be a temporary staging memory. The pointer is not
+   * allowed to be saved for later use by Mesa.
+   */
+   void *driver_data;
+
+   /* Structure version 2 ends here. */
+};
+
+#define MESA_GLINTEROP_EXPORT_IN_VERSION 1
+
+/**
+ * Input parameters to Mesa interop export functions.
+ */
+struct mesa_glinterop_export_in {
+   /* The caller should set this to the version of the struct they support */
+   /* The callee will overwrite it if it supports a lower version.
+    *
+    * The caller should check the value and access up-to the version supported
+    * by the callee.
+    */
+   /* NOTE: Do not use the MESA_GLINTEROP_EXPORT_IN_VERSION macro */
+   uint32_t version;
+
+   /* One of the following:
+    * - GL_TEXTURE_BUFFER
+    * - GL_TEXTURE_1D
+    * - GL_TEXTURE_2D
+    * - GL_TEXTURE_3D
+    * - GL_TEXTURE_RECTANGLE
+    * - GL_TEXTURE_1D_ARRAY
+    * - GL_TEXTURE_2D_ARRAY
+    * - GL_TEXTURE_CUBE_MAP_ARRAY
+    * - GL_TEXTURE_CUBE_MAP
+    * - GL_TEXTURE_CUBE_MAP_POSITIVE_X
+    * - GL_TEXTURE_CUBE_MAP_NEGATIVE_X
+    * - GL_TEXTURE_CUBE_MAP_POSITIVE_Y
+    * - GL_TEXTURE_CUBE_MAP_NEGATIVE_Y
+    * - GL_TEXTURE_CUBE_MAP_POSITIVE_Z
+    * - GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
+    * - GL_TEXTURE_2D_MULTISAMPLE
+    * - GL_TEXTURE_2D_MULTISAMPLE_ARRAY
+    * - GL_TEXTURE_EXTERNAL_OES
+    * - GL_RENDERBUFFER
+    * - GL_ARRAY_BUFFER
+    */
+   unsigned target;
+
+   /* If target is GL_ARRAY_BUFFER, it's a buffer object.
+    * If target is GL_RENDERBUFFER, it's a renderbuffer object.
+    * If target is GL_TEXTURE_*, it's a texture object.
+    */
+   unsigned obj;
+
+   /* Mipmap level. Ignored for non-texture objects. */
+   unsigned miplevel;
+
+   /* One of MESA_GLINTEROP_ACCESS_* flags. This describes how the exported
+    * object is going to be used.
+    */
+   uint32_t access;
+
+   /* Size of memory pointed to by out_driver_data. */
+   uint32_t out_driver_data_size;
+
+   /* If the caller wants to query driver-specific data about the OpenGL
+    * object, this should point to the memory where that data will be stored.
+    * This is expected to be a temporary staging memory. The pointer is not
+    * allowed to be saved for later use by Mesa.
+    */
+   void *out_driver_data;
+   /* Structure version 1 ends here. */
+};
+
+#define MESA_GLINTEROP_EXPORT_OUT_VERSION 1
+
+/**
+ * Outputs of Mesa interop export functions.
+ */
+struct mesa_glinterop_export_out {
+   /* The caller should set this to the version of the struct they support */
+   /* The callee will overwrite it if it supports a lower version.
+    *
+    * The caller should check the value and access up-to the version supported
+    * by the callee.
+    */
+   /* NOTE: Do not use the MESA_GLINTEROP_EXPORT_OUT_VERSION macro */
+   uint32_t version;
+
+#ifndef _WIN32
+   /* The DMABUF handle. It must be closed by the caller using the POSIX
+    * close() function when it's not needed anymore. Mesa is not responsible
+    * for closing the handle.
+    *
+    * Not closing the handle by the caller will lead to a resource leak,
+    * will prevent releasing the GPU buffer, and may prevent creating new
+    * DMABUF handles within the process.
+    */
+   int dmabuf_fd;
+#else
+   /* Same concept as a DMABUF, but for Windows/WDDM. It must be closed by
+    * the caller using CloseHandle() when it's not needed anymore.
+    */
+   HANDLE win32_handle;
+#endif
+
+   /* The mutable OpenGL internal format specified by glTextureView or
+    * glTexBuffer. If the object is not one of those, the original internal
+    * format specified by glTexStorage, glTexImage, or glRenderbufferStorage
+    * will be returned.
+    */
+   unsigned internal_format;
+
+   /* Buffer offset and size for GL_ARRAY_BUFFER and GL_TEXTURE_BUFFER.
+    * This allows interop with suballocations (a buffer allocated within
+    * a larger buffer).
+    *
+    * Parameters specified by glTexBufferRange for GL_TEXTURE_BUFFER are
+    * applied to these and can shrink the range further.
+    */
+   ptrdiff_t buf_offset;
+   ptrdiff_t buf_size;
+
+   /* Parameters specified by glTextureView. If the object is not a texture
+    * view, default parameters covering the whole texture will be returned.
+    */
+   unsigned view_minlevel;
+   unsigned view_numlevels;
+   unsigned view_minlayer;
+   unsigned view_numlayers;
+
+   /* The number of bytes written to out_driver_data. */
+   uint32_t out_driver_data_written;
+   /* Structure version 1 ends here. */
+};
+
+
+/**
+ * Query device information.
+ *
+ * \param dpy        GLX display
+ * \param context    GLX context
+ * \param out        where to return the information
+ *
+ * \return MESA_GLINTEROP_SUCCESS or MESA_GLINTEROP_* != 0 on error
+ */
+int
+MesaGLInteropGLXQueryDeviceInfo(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                                struct mesa_glinterop_device_info *out);
+
+
+/**
+ * Same as MesaGLInteropGLXQueryDeviceInfo except that it accepts EGLDisplay
+ * and EGLContext.
+ */
+int
+MesaGLInteropEGLQueryDeviceInfo(EGLDisplay dpy, EGLContext context,
+                                struct mesa_glinterop_device_info *out);
+
+
+/**
+* Same as MesaGLInteropGLXQueryDeviceInfo except that it accepts HDC
+* and HGLRC.
+*/
+int
+MesaGLInteropWGLQueryDeviceInfo(HDC dpy, HGLRC context,
+                                struct mesa_glinterop_device_info *out);
+
+/**
+ * Create and return a DMABUF handle corresponding to the given OpenGL
+ * object, and return other parameters about the OpenGL object.
+ *
+ * \param dpy        GLX display
+ * \param context    GLX context
+ * \param in         input parameters
+ * \param out        return values
+ *
+ * \return MESA_GLINTEROP_SUCCESS or MESA_GLINTEROP_* != 0 on error
+ */
+int
+MesaGLInteropGLXExportObject(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                             struct mesa_glinterop_export_in *in,
+                             struct mesa_glinterop_export_out *out);
+
+
+/**
+ * Same as MesaGLInteropGLXExportObject except that it accepts
+ * EGLDisplay and EGLContext.
+ */
+int
+MesaGLInteropEGLExportObject(EGLDisplay dpy, EGLContext context,
+                             struct mesa_glinterop_export_in *in,
+                             struct mesa_glinterop_export_out *out);
+
+
+/**
+* Same as MesaGLInteropGLXExportObject except that it accepts
+* HDC and HGLRC.
+*/
+int
+MesaGLInteropWGLExportObject(HDC dpy, HGLRC context,
+                             struct mesa_glinterop_export_in *in,
+                             struct mesa_glinterop_export_out *out);
+
+
+/**
+ * Prepare OpenGL resources for being accessed by OpenCL.
+ * 
+ * \param dpy        GLX display
+ * \param context    GLX context
+ * \param count      number of resources
+ * \param resources  resources to flush
+ * \param sync       optional GLsync to map to CL event
+ * 
+ * \return MESA_GLINTEROP_SUCCESS or MESA_GLINTEROP_* != 0 on error
+ */
+int
+MesaGLInteropGLXFlushObjects(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                             unsigned count, struct mesa_glinterop_export_in *resources,
+                             GLsync *sync);
+
+/**
+* Same as MesaGLInteropGLXFlushObjects except that it accepts
+* EGLDisplay and EGLContext.
+*/
+int
+MesaGLInteropEGLFlushObjects(EGLDisplay dpy, EGLContext context,
+                             unsigned count, struct mesa_glinterop_export_in *resources,
+                             GLsync *sync);
+
+/**
+* Same as MesaGLInteropGLXFlushObjects except that it accepts
+* HDC and HGLRC.
+*/
+int
+MesaGLInteropWGLFlushObjects(HDC dpy, HGLRC context,
+                             unsigned count, struct mesa_glinterop_export_in *resources,
+                             GLsync *sync);
+
+
+typedef int (PFNMESAGLINTEROPGLXQUERYDEVICEINFOPROC)(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                                                     struct mesa_glinterop_device_info *out);
+typedef int (PFNMESAGLINTEROPEGLQUERYDEVICEINFOPROC)(EGLDisplay dpy, EGLContext context,
+                                                     struct mesa_glinterop_device_info *out);
+typedef int (PFNMESAGLINTEROPWGLQUERYDEVICEINFOPROC)(HDC dpy, HGLRC context,
+                                                     struct mesa_glinterop_device_info *out);
+typedef int (PFNMESAGLINTEROPGLXEXPORTOBJECTPROC)(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                                                  struct mesa_glinterop_export_in *in,
+                                                  struct mesa_glinterop_export_out *out);
+typedef int (PFNMESAGLINTEROPEGLEXPORTOBJECTPROC)(EGLDisplay dpy, EGLContext context,
+                                                  struct mesa_glinterop_export_in *in,
+                                                  struct mesa_glinterop_export_out *out);
+typedef int (PFNMESAGLINTEROPWGLEXPORTOBJECTPROC)(HDC dpy, HGLRC context,
+                                                  struct mesa_glinterop_export_in *in,
+                                                  struct mesa_glinterop_export_out *out);
+typedef int (PFNMESAGLINTEROPGLXFLUSHOBJECTSPROC)(struct _XDisplay *dpy, struct __GLXcontextRec *context,
+                                                  unsigned count, struct mesa_glinterop_export_in *resources,
+                                                  GLsync *sync);
+typedef int (PFNMESAGLINTEROPEGLFLUSHOBJECTSPROC)(EGLDisplay dpy, EGLContext context,
+                                                  unsigned count, struct mesa_glinterop_export_in *resources,
+                                                  GLsync *sync);
+typedef int (PFNMESAGLINTEROPWGLFLUSHOBJECTSPROC)(HDC dpy, HGLRC context,
+                                                  unsigned count, struct mesa_glinterop_export_in *resources,
+                                                  GLsync *sync);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MESA_GLINTEROP_H */

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -8,6 +8,8 @@
 struct GLProperties;
 struct d3d12_interop_device_info;
 struct mesa_glinterop_device_info;
+struct mesa_glinterop_export_in;
+struct mesa_glinterop_export_out;
 typedef struct __GLsync *GLsync;
 
 class GLInteropManager
@@ -16,6 +18,7 @@ public:
     static std::unique_ptr<GLInteropManager> Create(GLProperties const &glProps);
     virtual ~GLInteropManager() = default;
     virtual bool GetDeviceData(d3d12_interop_device_info &d3d12DevInfo) = 0;
+    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) = 0;
     bool SyncWait(GLsync fence);
     void DeleteSync(GLsync fence);
 protected:
@@ -98,6 +101,7 @@ public:
     Device& GetDevice(cl_uint index) const noexcept;
     D3DDevice &GetD3DDevice(cl_uint index) const noexcept;
     D3DDevice *D3DDeviceForContext(Device &device) const noexcept;
+    GLInteropManager *GetGLManager() const noexcept { return m_GLInteropManager.get(); }
     std::vector<D3DDeviceAndRef> GetDevices() const noexcept { return m_AssociatedDevices; }
 
     void AddDestructionCallback(DestructorCallback::Fn pfn, void* pUserData);

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -5,6 +5,8 @@
 #include "platform.hpp"
 #include "device.hpp"
 
+class GLInteropManager;
+
 class Context : public CLChildBase<Context, Platform, cl_context>
 {
 public:
@@ -30,12 +32,17 @@ private:
     mutable std::mutex m_DestructorLock;
     std::vector<DestructorCallback> m_DestructorCallbacks;
 
+    std::unique_ptr<GLInteropManager> m_GLInteropManager;
+
     static void CL_CALLBACK DummyCallback(const char*, const void*, size_t, void*) {}
 
     friend cl_int CL_API_CALL clGetContextInfo(cl_context, cl_context_info, size_t, void*, size_t*);
 
 public:
-    Context(Platform& Platform, std::vector<D3DDeviceAndRef> Devices, const cl_context_properties* Properties, PfnCallbackType pfnErrorCb, void* CallbackContext);
+    Context(Platform& Platform, std::vector<D3DDeviceAndRef> Devices,
+            const cl_context_properties* Properties,
+            std::unique_ptr<GLInteropManager> glManager,
+            PfnCallbackType pfnErrorCb, void* CallbackContext);
     ~Context();
 
     void ReportError(const char* Error);

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -21,7 +21,7 @@ public:
     };
 
 private:
-    std::vector<Device::ref_ptr_int> m_AssociatedDevices;
+    std::vector<D3DDeviceAndRef> m_AssociatedDevices;
     const PfnCallbackType m_ErrorCallback;
     void* const m_CallbackContext;
 
@@ -35,7 +35,7 @@ private:
     friend cl_int CL_API_CALL clGetContextInfo(cl_context, cl_context_info, size_t, void*, size_t*);
 
 public:
-    Context(Platform& Platform, std::vector<Device::ref_ptr_int> Devices, const cl_context_properties* Properties, PfnCallbackType pfnErrorCb, void* CallbackContext);
+    Context(Platform& Platform, std::vector<D3DDeviceAndRef> Devices, const cl_context_properties* Properties, PfnCallbackType pfnErrorCb, void* CallbackContext);
     ~Context();
 
     void ReportError(const char* Error);
@@ -64,8 +64,10 @@ public:
 
     cl_uint GetDeviceCount() const noexcept;
     Device& GetDevice(cl_uint index) const noexcept;
+    D3DDevice &GetD3DDevice(cl_uint index) const noexcept;
     bool ValidDeviceForContext(Device& device) const noexcept;
-    std::vector<Device::ref_ptr_int> GetDevices() const noexcept { return m_AssociatedDevices; }
+    D3DDevice *D3DDeviceForContext(Device &device) const noexcept;
+    std::vector<D3DDeviceAndRef> GetDevices() const noexcept { return m_AssociatedDevices; }
 
     void AddDestructionCallback(DestructorCallback::Fn pfn, void* pUserData);
 };

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -4,13 +4,13 @@
 
 #include "platform.hpp"
 #include "device.hpp"
+#include "gl_tokens.hpp"
 
 struct GLProperties;
 struct d3d12_interop_device_info;
 struct mesa_glinterop_device_info;
 struct mesa_glinterop_export_in;
 struct mesa_glinterop_export_out;
-typedef struct __GLsync *GLsync;
 
 class GLInteropManager
 {
@@ -31,8 +31,8 @@ protected:
     {
     }
     XPlatHelpers::unique_module m_hMod;
-    void(__stdcall *m_WaitSync)(GLsync, unsigned flags, uint64_t timeout);
-    void(__stdcall *m_DeleteSync)(GLsync);
+    decltype(&glWaitSync) m_WaitSync;
+    decltype(&glDeleteSync) m_DeleteSync;
 };
 
 class Context : public CLChildBase<Context, Platform, cl_context>

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -39,7 +39,7 @@ private:
     friend cl_int CL_API_CALL clGetContextInfo(cl_context, cl_context_info, size_t, void*, size_t*);
 
 public:
-    Context(Platform& Platform, std::vector<D3DDeviceAndRef> Devices,
+    Context(std::vector<D3DDeviceAndRef> Devices,
             const cl_context_properties* Properties,
             std::unique_ptr<GLInteropManager> glManager,
             PfnCallbackType pfnErrorCb, void* CallbackContext);

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -18,7 +18,7 @@ public:
     static std::unique_ptr<GLInteropManager> Create(GLProperties const &glProps);
     virtual ~GLInteropManager() = default;
     virtual bool GetDeviceData(d3d12_interop_device_info &d3d12DevInfo) = 0;
-    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) = 0;
+    virtual int GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) = 0;
     virtual bool AcquireResources(std::vector<mesa_glinterop_export_in> &resources, GLsync *sync) = 0;
     virtual bool IsAppContextBoundToThread() = 0;
     bool SyncWait(GLsync fence, bool deleteSync);

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -65,7 +65,6 @@ public:
     cl_uint GetDeviceCount() const noexcept;
     Device& GetDevice(cl_uint index) const noexcept;
     D3DDevice &GetD3DDevice(cl_uint index) const noexcept;
-    bool ValidDeviceForContext(Device& device) const noexcept;
     D3DDevice *D3DDeviceForContext(Device &device) const noexcept;
     std::vector<D3DDeviceAndRef> GetDevices() const noexcept { return m_AssociatedDevices; }
 

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -10,13 +10,14 @@
 using ImmCtx = D3D12TranslationLayer::ImmediateContext;
 
 class Task;
+class Device;
 
 using Submission = std::vector<::ref_ptr_int<Task>>;
 
 class D3DDevice
 {
 public:
-    D3DDevice(ID3D12Device *pDevice, D3D12_FEATURE_DATA_D3D12_OPTIONS &options);
+    D3DDevice(Device &parent,  ID3D12Device *pDevice, D3D12_FEATURE_DATA_D3D12_OPTIONS &options);
     ~D3DDevice() = default;
 
     ID3D12Device* GetDevice() const noexcept { return m_spDevice.Get(); }
@@ -35,6 +36,7 @@ public:
 protected:
     void ExecuteTasks(Submission& tasks);
 
+    Device &m_Parent;
     const ComPtr<ID3D12Device> m_spDevice;
     const D3D12TranslationLayer::TranslationLayerCallbacks m_Callbacks;
     ::ImmCtx m_ImmCtx;
@@ -68,7 +70,7 @@ public:
 
     std::string GetDeviceName() const;
 
-    void InitD3D();
+    D3DDevice &InitD3D();
     void ReleaseD3D();
 
     std::optional<::D3DDevice> &D3DDevice() { return m_D3DDevice; }
@@ -88,3 +90,5 @@ protected:
     D3D12_FEATURE_DATA_ARCHITECTURE m_Architecture = {};
     unsigned m_ContextCount = 0;
 };
+
+using D3DDeviceAndRef = std::pair<Device::ref_ptr_int, D3DDevice *>;

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -70,6 +70,7 @@ public:
     bool SupportsTypedUAVLoad();
 
     std::string GetDeviceName() const;
+    LUID GetAdapterLuid() const;
 
     D3DDevice &InitD3D();
     void ReleaseD3D();

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -13,6 +13,45 @@ class Task;
 
 using Submission = std::vector<::ref_ptr_int<Task>>;
 
+class D3DDevice
+{
+public:
+    D3DDevice(ID3D12Device *pDevice, D3D12_FEATURE_DATA_D3D12_OPTIONS &options);
+    ~D3DDevice() = default;
+
+    ID3D12Device* GetDevice() const noexcept { return m_spDevice.Get(); }
+    ShaderCache &GetShaderCache() const noexcept { return m_ShaderCache; }
+
+    ImmCtx& ImmCtx() noexcept { return m_ImmCtx; }
+    UINT64 GetTimestampFrequency() const noexcept { return m_TimestampFrequency; }
+    INT64 GPUToQPCTimestampOffset() const noexcept { return m_GPUToQPCTimestampOffset; }
+
+    void SubmitTask(Task*, TaskPoolLock const&);
+    void ReadyTask(Task*, TaskPoolLock const&);
+    void Flush(TaskPoolLock const&);
+
+    std::unique_ptr<D3D12TranslationLayer::PipelineState> CreatePSO(D3D12TranslationLayer::COMPUTE_PIPELINE_STATE_DESC const& Desc);
+
+protected:
+    void ExecuteTasks(Submission& tasks);
+
+    const ComPtr<ID3D12Device> m_spDevice;
+    const D3D12TranslationLayer::TranslationLayerCallbacks m_Callbacks;
+    ::ImmCtx m_ImmCtx;
+
+    std::unique_ptr<Submission> m_RecordingSubmission;
+
+    BackgroundTaskScheduler::Scheduler m_CompletionScheduler;
+    mutable ShaderCache m_ShaderCache;
+
+    // All PSO creations need to be kicked off behind this lock,
+    // which guards the root signature cache in the immediate context
+    std::mutex m_PSOCreateLock;
+
+    UINT64 m_TimestampFrequency = 0;
+    INT64 m_GPUToQPCTimestampOffset = 0;
+};
+
 class Device : public CLChildBase<Device, Platform, cl_device_id>
 {
 public:
@@ -26,30 +65,20 @@ public:
     bool IsUMA();
     bool SupportsInt16();
     bool SupportsTypedUAVLoad();
-    ShaderCache& GetShaderCache();
 
     std::string GetDeviceName() const;
 
     void InitD3D();
     void ReleaseD3D();
-    ID3D12Device* GetDevice() const { return m_spDevice.Get(); }
-    ImmCtx& ImmCtx() { return m_ImmCtx.value(); }
-    UINT64 GetTimestampFrequency() const { return m_TimestampFrequency; }
-    INT64 GPUToQPCTimestampOffset() const { return m_GPUToQPCTimestampOffset; }
 
-    void SubmitTask(Task*, TaskPoolLock const&);
-    void ReadyTask(Task*, TaskPoolLock const&);
-    void Flush(TaskPoolLock const&);
-
-    std::unique_ptr<D3D12TranslationLayer::PipelineState> CreatePSO(D3D12TranslationLayer::COMPUTE_PIPELINE_STATE_DESC const& Desc);
+    std::optional<::D3DDevice> &D3DDevice() { return m_D3DDevice; }
 
 protected:
-    void ExecuteTasks(Submission& tasks);
-    void CacheCaps(std::lock_guard<std::mutex> const&);
+    void CacheCaps(std::lock_guard<std::mutex> const&, ComPtr<ID3D12Device> spDevice = {});
 
     ComPtr<IDXCoreAdapter> m_spAdapter;
-    ComPtr<ID3D12Device> m_spDevice;
     DXCoreHardwareID m_HWIDs;
+    std::optional<::D3DDevice> m_D3DDevice;
 
     // Lazy-initialized
     std::mutex m_InitLock;
@@ -57,19 +86,5 @@ protected:
     D3D12_FEATURE_DATA_D3D12_OPTIONS m_D3D12Options = {};
     D3D12_FEATURE_DATA_D3D12_OPTIONS4 m_D3D12Options4 = {};
     D3D12_FEATURE_DATA_ARCHITECTURE m_Architecture = {};
-    D3D12TranslationLayer::TranslationLayerCallbacks m_Callbacks;
-    std::optional<::ImmCtx> m_ImmCtx;
     unsigned m_ContextCount = 0;
-
-    std::unique_ptr<Submission> m_RecordingSubmission;
-
-    BackgroundTaskScheduler::Scheduler m_CompletionScheduler;
-    std::optional<ShaderCache> m_ShaderCache;
-
-    // All PSO creations need to be kicked off behind this lock,
-    // which guards the root signature cache in the immediate context
-    std::mutex m_PSOCreateLock;
-
-    UINT64 m_TimestampFrequency = 0;
-    INT64 m_GPUToQPCTimestampOffset = 0;
 };

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -32,6 +32,7 @@ public:
     void Flush(TaskPoolLock const&);
 
     std::unique_ptr<D3D12TranslationLayer::PipelineState> CreatePSO(D3D12TranslationLayer::COMPUTE_PIPELINE_STATE_DESC const& Desc);
+    Device &GetParent() const noexcept { return m_Parent; }
 
 protected:
     void ExecuteTasks(Submission& tasks);
@@ -73,7 +74,8 @@ public:
     D3DDevice &InitD3D();
     void ReleaseD3D();
 
-    std::optional<::D3DDevice> &D3DDevice() { return m_D3DDevice; }
+    bool HasD3DDevice() const noexcept { return m_D3DDevice.has_value(); }
+    void CloseCaches();
 
 protected:
     void CacheCaps(std::lock_guard<std::mutex> const&, ComPtr<ID3D12Device> spDevice = {});

--- a/include/formats.hpp
+++ b/include/formats.hpp
@@ -176,6 +176,8 @@ constexpr cl_image_format GetCLImageFormatForDXGIFormat(DXGI_FORMAT fmt, cl_GLui
         case GL_RGBA8UI: return { CL_RGBA, CL_UNSIGNED_INT8 };
         case GL_RGBA8_SNORM: return { CL_RGBA, CL_SNORM_INT8 };
         case GL_RGBA8I: return { CL_RGBA, CL_SIGNED_INT8 };
+        case GL_UNSIGNED_INT_8_8_8_8_REV: return { CL_RGBA, CL_UNORM_INT8 };
+        case GL_RGBA: return { CL_RGBA, CL_UNORM_INT8 };
         }
         break;
     case DXGI_FORMAT_R16G16_FLOAT: return { CL_RG, CL_HALF_FLOAT };
@@ -248,6 +250,53 @@ constexpr cl_image_format GetCLImageFormatForDXGIFormat(DXGI_FORMAT fmt, cl_GLui
     case DXGI_FORMAT_A8_UNORM: return { CL_A, CL_UNORM_INT8 };
     case DXGI_FORMAT_B8G8R8A8_UNORM: return { CL_BGRA, CL_UNORM_INT8 };
     case DXGI_FORMAT_B8G8R8A8_TYPELESS: return { CL_BGRA, CL_UNORM_INT8 };
+    }
+    return {};
+}
+
+constexpr cl_image_format GetCLImageFormatForGLFormat(cl_GLuint fmt)
+{
+    switch (fmt)
+    {
+    case GL_RGBA32F: return { CL_RGBA, CL_FLOAT };
+    case GL_RGBA32UI: return { CL_RGBA, CL_UNSIGNED_INT32 };
+    case GL_RGBA32I: return { CL_RGBA, CL_SIGNED_INT32 };
+    case GL_RGBA16F: return { CL_RGBA, CL_HALF_FLOAT };
+    case GL_RGBA16: return { CL_RGBA, CL_UNORM_INT16 };
+    case GL_RGBA16UI: return { CL_RGBA, CL_UNSIGNED_INT16 };
+    case GL_RGBA16_SNORM: return { CL_RGBA, CL_SNORM_INT16 };
+    case GL_RGBA16I: return { CL_RGBA, CL_SIGNED_INT16 };
+    case GL_RG32F: return { CL_RG, CL_FLOAT };
+    case GL_RG32UI: return { CL_RG, CL_UNSIGNED_INT32 };
+    case GL_RG32I: return { CL_RG, CL_SIGNED_INT32 };
+    case GL_RGBA8: return { CL_RGBA, CL_UNORM_INT8 };
+    case GL_RGBA8UI: return { CL_RGBA, CL_UNSIGNED_INT8 };
+    case GL_RGBA8_SNORM: return { CL_RGBA, CL_SNORM_INT8 };
+    case GL_RGBA8I: return { CL_RGBA, CL_SIGNED_INT8 };
+    case GL_UNSIGNED_INT_8_8_8_8_REV: return { CL_RGBA, CL_UNORM_INT8 };
+    case GL_RGBA: return { CL_RGBA, CL_UNORM_INT8 };
+    case GL_RG16F: return { CL_RG, CL_HALF_FLOAT };
+    case GL_RG16: return { CL_RG, CL_UNORM_INT16 };
+    case GL_RG16UI: return { CL_RG, CL_UNSIGNED_INT16 };
+    case GL_RG16_SNORM: return { CL_RG, CL_SNORM_INT16 };
+    case GL_RG16I: return { CL_RG, CL_SIGNED_INT16 };
+    case GL_R32F: return { CL_R, CL_FLOAT };
+    case GL_R32UI: return { CL_R, CL_UNSIGNED_INT32 };
+    case GL_R32I: return { CL_R, CL_SIGNED_INT32 };
+    case GL_RG8: return { CL_RG, CL_UNORM_INT8 };
+    case GL_RG8UI: return { CL_RG, CL_UNSIGNED_INT8 };
+    case GL_RG8_SNORM: return { CL_RG, CL_SNORM_INT8 };
+    case GL_RG8I: return { CL_RG, CL_SIGNED_INT8 };
+    case GL_R16F: return { CL_R, CL_HALF_FLOAT };
+    case GL_R16: return { CL_R, CL_UNORM_INT16 };
+    case GL_R16UI: return { CL_R, CL_UNSIGNED_INT16 };
+    case GL_R16_SNORM: return { CL_R, CL_SNORM_INT16 };
+    case GL_R16I: return { CL_R, CL_SIGNED_INT16 };
+    case GL_R8: return { CL_R, CL_UNORM_INT8 };
+    case GL_R8UI: return { CL_R, CL_UNSIGNED_INT8 };
+    case GL_R8_SNORM: return { CL_R, CL_SNORM_INT8 };
+    case GL_R8I: return { CL_R, CL_SIGNED_INT8 };
+    case GL_BGRA: return { CL_BGRA, CL_UNORM_INT8 };
     }
     return {};
 }

--- a/include/formats.hpp
+++ b/include/formats.hpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include <limits>
+#include "gl_tokens.hpp"
 
 constexpr DXGI_FORMAT GetDXGIFormatForCLImageFormat(cl_image_format const& image_format)
 {
@@ -118,13 +119,21 @@ constexpr DXGI_FORMAT GetDXGIFormatForCLImageFormat(cl_image_format const& image
     return DXGI_FORMAT_UNKNOWN;
 }
 
-constexpr cl_image_format GetCLImageFormatForDXGIFormat(DXGI_FORMAT fmt)
+constexpr cl_image_format GetCLImageFormatForDXGIFormat(DXGI_FORMAT fmt, cl_GLuint glFmt)
 {
     switch (fmt)
     {
     case DXGI_FORMAT_R32G32B32A32_FLOAT: return { CL_RGBA, CL_FLOAT };
     case DXGI_FORMAT_R32G32B32A32_UINT: return { CL_RGBA, CL_UNSIGNED_INT32 };
     case DXGI_FORMAT_R32G32B32A32_SINT: return { CL_RGBA, CL_SIGNED_INT32 };
+    case DXGI_FORMAT_R32G32B32A32_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RGBA32F: return { CL_RGBA, CL_FLOAT };
+        case GL_RGBA32UI: return { CL_RGBA, CL_UNSIGNED_INT32 };
+        case GL_RGBA32I: return { CL_RGBA, CL_SIGNED_INT32 };
+        }
+        break;
     case DXGI_FORMAT_R32G32B32_FLOAT: return { CL_RGB, CL_FLOAT };
     case DXGI_FORMAT_R32G32B32_UINT: return { CL_RGB, CL_UNSIGNED_INT32 };
     case DXGI_FORMAT_R32G32B32_SINT: return { CL_RGB, CL_SIGNED_INT32 };
@@ -133,38 +142,112 @@ constexpr cl_image_format GetCLImageFormatForDXGIFormat(DXGI_FORMAT fmt)
     case DXGI_FORMAT_R16G16B16A16_UINT: return { CL_RGBA, CL_UNSIGNED_INT16 };
     case DXGI_FORMAT_R16G16B16A16_SNORM: return { CL_RGBA, CL_SNORM_INT16 };
     case DXGI_FORMAT_R16G16B16A16_SINT: return { CL_RGBA, CL_SIGNED_INT16 };
+    case DXGI_FORMAT_R16G16B16A16_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RGBA16F: return { CL_RGBA, CL_HALF_FLOAT };
+        case GL_RGBA16: return { CL_RGBA, CL_UNORM_INT16 };
+        case GL_RGBA16UI: return { CL_RGBA, CL_UNSIGNED_INT16 };
+        case GL_RGBA16_SNORM: return { CL_RGBA, CL_SNORM_INT16 };
+        case GL_RGBA16I: return { CL_RGBA, CL_SIGNED_INT16 };
+        }
+        break;
     case DXGI_FORMAT_R32G32_FLOAT: return { CL_RG, CL_FLOAT };
     case DXGI_FORMAT_R32G32_UINT: return { CL_RG, CL_UNSIGNED_INT32 };
     case DXGI_FORMAT_R32G32_SINT: return { CL_RG, CL_SIGNED_INT32 };
+    case DXGI_FORMAT_R32G32_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RG32F: return { CL_RG, CL_FLOAT };
+        case GL_RG32UI: return { CL_RG, CL_UNSIGNED_INT32 };
+        case GL_RG32I: return { CL_RG, CL_SIGNED_INT32 };
+        }
+        break;
     // This is failing a bunch of tests - see about re-enabling as a proper 1010102
     //case DXGI_FORMAT_R10G10B10A2_UNORM: return { CL_RGBx, CL_UNORM_INT_101010 };
     case DXGI_FORMAT_R8G8B8A8_UNORM: return { CL_RGBA, CL_UNORM_INT8 };
     case DXGI_FORMAT_R8G8B8A8_UINT: return { CL_RGBA, CL_UNSIGNED_INT8 };
     case DXGI_FORMAT_R8G8B8A8_SNORM: return { CL_RGBA, CL_SNORM_INT8 };
     case DXGI_FORMAT_R8G8B8A8_SINT: return { CL_RGBA, CL_SIGNED_INT8 };
+    case DXGI_FORMAT_R8G8B8A8_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RGBA8: return { CL_RGBA, CL_UNORM_INT8 };
+        case GL_RGBA8UI: return { CL_RGBA, CL_UNSIGNED_INT8 };
+        case GL_RGBA8_SNORM: return { CL_RGBA, CL_SNORM_INT8 };
+        case GL_RGBA8I: return { CL_RGBA, CL_SIGNED_INT8 };
+        }
+        break;
     case DXGI_FORMAT_R16G16_FLOAT: return { CL_RG, CL_HALF_FLOAT };
     case DXGI_FORMAT_R16G16_UNORM: return { CL_RG, CL_UNORM_INT16 };
     case DXGI_FORMAT_R16G16_UINT: return { CL_RG, CL_UNSIGNED_INT16 };
     case DXGI_FORMAT_R16G16_SNORM: return { CL_RG, CL_SNORM_INT16 };
     case DXGI_FORMAT_R16G16_SINT: return { CL_RG, CL_SIGNED_INT16 };
+    case DXGI_FORMAT_R16G16_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RG16F: return { CL_RG, CL_HALF_FLOAT };
+        case GL_RG16: return { CL_RG, CL_UNORM_INT16 };
+        case GL_RG16UI: return { CL_RG, CL_UNSIGNED_INT16 };
+        case GL_RG16_SNORM: return { CL_RG, CL_SNORM_INT16 };
+        case GL_RG16I: return { CL_RG, CL_SIGNED_INT16 };
+        }
+        break;
     case DXGI_FORMAT_R32_FLOAT: return { CL_R, CL_FLOAT };
     case DXGI_FORMAT_R32_UINT: return { CL_R, CL_UNSIGNED_INT32 };
     case DXGI_FORMAT_R32_SINT: return { CL_R, CL_SIGNED_INT32 };
+    case DXGI_FORMAT_R32_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_R32F: return { CL_R, CL_FLOAT };
+        case GL_R32UI: return { CL_R, CL_UNSIGNED_INT32 };
+        case GL_R32I: return { CL_R, CL_SIGNED_INT32 };
+        }
+        break;
     case DXGI_FORMAT_R8G8_UNORM: return { CL_RG, CL_UNORM_INT8 };
     case DXGI_FORMAT_R8G8_UINT: return { CL_RG, CL_UNSIGNED_INT8 };
     case DXGI_FORMAT_R8G8_SNORM: return { CL_RG, CL_SNORM_INT8 };
     case DXGI_FORMAT_R8G8_SINT: return { CL_RG, CL_SIGNED_INT8 };
+    case DXGI_FORMAT_R8G8_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_RG8: return { CL_RG, CL_UNORM_INT8 };
+        case GL_RG8UI: return { CL_RG, CL_UNSIGNED_INT8 };
+        case GL_RG8_SNORM: return { CL_RG, CL_SNORM_INT8 };
+        case GL_RG8I: return { CL_RG, CL_SIGNED_INT8 };
+        }
+        break;
     case DXGI_FORMAT_R16_FLOAT: return { CL_R, CL_HALF_FLOAT };
     case DXGI_FORMAT_R16_UNORM: return { CL_R, CL_UNORM_INT16 };
     case DXGI_FORMAT_R16_UINT: return { CL_R, CL_UNSIGNED_INT16 };
     case DXGI_FORMAT_R16_SNORM: return { CL_R, CL_SNORM_INT16 };
     case DXGI_FORMAT_R16_SINT: return { CL_R, CL_SIGNED_INT16 };
+    case DXGI_FORMAT_R16_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_R16F: return { CL_R, CL_HALF_FLOAT };
+        case GL_R16: return { CL_R, CL_UNORM_INT16 };
+        case GL_R16UI: return { CL_R, CL_UNSIGNED_INT16 };
+        case GL_R16_SNORM: return { CL_R, CL_SNORM_INT16 };
+        case GL_R16I: return { CL_R, CL_SIGNED_INT16 };
+        }
+        break;
     case DXGI_FORMAT_R8_UNORM: return { CL_R, CL_UNORM_INT8 };
     case DXGI_FORMAT_R8_UINT: return { CL_R, CL_UNSIGNED_INT8 };
     case DXGI_FORMAT_R8_SNORM: return { CL_R, CL_SNORM_INT8 };
     case DXGI_FORMAT_R8_SINT: return { CL_R, CL_SIGNED_INT8 };
+    case DXGI_FORMAT_R8_TYPELESS:
+        switch (glFmt)
+        {
+        case GL_R8: return { CL_R, CL_UNORM_INT8 };
+        case GL_R8UI: return { CL_R, CL_UNSIGNED_INT8 };
+        case GL_R8_SNORM: return { CL_R, CL_SNORM_INT8 };
+        case GL_R8I: return { CL_R, CL_SIGNED_INT8 };
+        }
+        break;
     case DXGI_FORMAT_A8_UNORM: return { CL_A, CL_UNORM_INT8 };
     case DXGI_FORMAT_B8G8R8A8_UNORM: return { CL_BGRA, CL_UNORM_INT8 };
+    case DXGI_FORMAT_B8G8R8A8_TYPELESS: return { CL_BGRA, CL_UNORM_INT8 };
     }
     return {};
 }

--- a/include/gl_tokens.hpp
+++ b/include/gl_tokens.hpp
@@ -88,4 +88,5 @@ EGLBoolean WINAPI eglTerminate(EGLDisplay);
 EGLContext WINAPI eglCreateContext(EGLDisplay, EGLConfig, EGLContext, const int32_t *);
 EGLBoolean WINAPI eglMakeCurrent(EGLDisplay, EGLSurface, EGLSurface, EGLContext);
 EGLBoolean WINAPI eglDestroyContext(EGLDisplay, EGLContext);
+EGLContext WINAPI eglGetCurrentContext();
 __eglMustCastToProperFunctionPointerType WINAPI eglGetProcAddress(const char *);

--- a/include/gl_tokens.hpp
+++ b/include/gl_tokens.hpp
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <gl/GL.h>
+
+// This header contains just the small subset of GL function
+// definitions and defines needed for GL/CL interop, without
+// pulling in all of glext.h
+
+#define GL_ARRAY_BUFFER 0x8892
+#define GL_RENDERBUFFER 0x8D41
+#define GL_TEXTURE_BUFFER 0x8C2A
+#define GL_TEXTURE_1D 0x0DE0
+#define GL_TEXTURE_2D 0x0DE1
+#define GL_TEXTURE_3D 0x806F
+#define GL_TEXTURE_RECTANGLE 0x84F5
+#define GL_TEXTURE_1D_ARRAY 0x8C18
+#define GL_TEXTURE_2D_ARRAY 0x8C1A
+#define GL_TEXTURE_CUBE_MAP_ARRAY 0x9009
+#define GL_TEXTURE_CUBE_MAP 0x8513
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_X 0x8515
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_X 0x8516
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Y 0x8517
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Y 0x8518
+#define GL_TEXTURE_CUBE_MAP_POSITIVE_Z 0x8519
+#define GL_TEXTURE_CUBE_MAP_NEGATIVE_Z 0x851A
+#define GL_TEXTURE_2D_MULTISAMPLE 0x9100
+#define GL_TEXTURE_2D_MULTISAMPLE_ARRAY 0x9102
+
+#define GL_RGBA8                          0x8058
+#define GL_SRGB8_ALPHA8                   0x8C43
+#define GL_RGBA                           0x1908
+#define GL_BGRA                           0x80E1
+#define GL_UNSIGNED_INT_8_8_8_8_REV       0x8367
+#define GL_RGBA8I                         0x8D8E
+#define GL_RGBA16I                        0x8D88
+#define GL_RGBA32I                        0x8D82
+#define GL_RGBA8UI                        0x8D7C
+#define GL_RGBA16UI                       0x8D76
+#define GL_RGBA32UI                       0x8D70
+#define GL_RGBA8_SNORM                    0x8F97
+#define GL_RGBA16                         0x805B
+#define GL_RGBA16_SNORM                   0x8F9B
+#define GL_RGBA16F                        0x881A
+#define GL_RGBA32F                        0x8814
+#define GL_R8                             0x8229
+#define GL_R8_SNORM                       0x8F94
+#define GL_R16                            0x822A
+#define GL_R16_SNORM                      0x8F98
+#define GL_R16F                           0x822D
+#define GL_R32F                           0x822E
+#define GL_R8I                            0x8231
+#define GL_R16I                           0x8233
+#define GL_R32I                           0x8235
+#define GL_R8UI                           0x8232
+#define GL_R16UI                          0x8234
+#define GL_R32UI                          0x8236
+#define GL_RG8                            0x822B
+#define GL_RG8_SNORM                      0x8F95
+#define GL_RG16                           0x822C
+#define GL_RG16_SNORM                     0x8F99
+#define GL_RG16F                          0x822F
+#define GL_RG32F                          0x8230
+#define GL_RG8I                           0x8237
+#define GL_RG16I                          0x8239
+#define GL_RG32I                          0x823B
+#define GL_RG8UI                          0x8238
+#define GL_RG16UI                         0x823A
+#define GL_RG32UI                         0x823C
+
+#define EGL_PLATFORM_SURFACELESS_MESA 0x31DD
+
+HGLRC WINAPI wglCreateContextAttribsARB(HDC, HGLRC, const int *);
+
+typedef struct __GLsync *GLsync;
+void WINAPI glWaitSync(GLsync, unsigned flags, uint64_t timeout);
+void WINAPI glDeleteSync(GLsync);
+
+typedef void *EGLDisplay, *EGLSurface, *EGLContext, *EGLConfig;
+typedef unsigned int EGLBoolean, EGLenum;
+typedef intptr_t EGLAttrib;
+typedef int32_t EGLint;
+typedef void (*__eglMustCastToProperFunctionPointerType)(void);
+EGLDisplay WINAPI eglGetPlatformDisplay(EGLenum, void *, const EGLAttrib *);
+EGLBoolean WINAPI eglInitialize(EGLDisplay, EGLint *, EGLint *);
+EGLBoolean WINAPI eglTerminate(EGLDisplay);
+EGLContext WINAPI eglCreateContext(EGLDisplay, EGLConfig, EGLContext, const int32_t *);
+EGLBoolean WINAPI eglMakeCurrent(EGLDisplay, EGLSurface, EGLSurface, EGLContext);
+EGLBoolean WINAPI eglDestroyContext(EGLDisplay, EGLContext);
+__eglMustCastToProperFunctionPointerType WINAPI eglGetProcAddress(const char *);

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -111,7 +111,9 @@ public:
                                               "cl_khr_local_int32_extended_atomics "
                                               "cl_khr_byte_addressable_store "
                                               "cl_khr_il_program "
-                                              "cl_khr_3d_image_writes ";
+                                              "cl_khr_3d_image_writes "
+                                              "cl_khr_gl_sharing "
+                                              "cl_khr_gl_event ";
     static constexpr const char* ICDSuffix = "oclon12";
 
     Platform(cl_icd_dispatch* dispatch);

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -124,7 +124,6 @@ public:
     void UnloadCompiler();
 
     TaskPoolLock GetTaskPoolLock();
-    void FlushAllDevices(TaskPoolLock const& Lock);
 
     bool AnyD3DDevicesExist() const noexcept;
     void CloseCaches();

--- a/include/program.hpp
+++ b/include/program.hpp
@@ -21,11 +21,11 @@ public:
 
     Program(Context& Parent, std::string Source);
     Program(Context& Parent, std::vector<std::byte> IL);
-    Program(Context& Parent, std::vector<Device::ref_ptr_int> Devices);
+    Program(Context& Parent, std::vector<D3DDeviceAndRef> Devices);
     using Callback = void(CL_CALLBACK*)(cl_program, void*);
 
-    cl_int Build(std::vector<Device::ref_ptr_int> Devices, const char* options, Callback pfn_notify, void* user_data);
-    cl_int Compile(std::vector<Device::ref_ptr_int> Devices, const char* options, cl_uint num_input_headers, const cl_program *input_headers, const char**header_include_names, Callback pfn_notify, void* user_data);
+    cl_int Build(std::vector<D3DDeviceAndRef> Devices, const char* options, Callback pfn_notify, void* user_data);
+    cl_int Compile(std::vector<D3DDeviceAndRef> Devices, const char* options, cl_uint num_input_headers, const cl_program *input_headers, const char**header_include_names, Callback pfn_notify, void* user_data);
     cl_int Link(const char* options, cl_uint num_input_programs, const cl_program* input_programs, Callback pfn_notify, void* user_data);
 
     void StoreBinary(Device* Device, unique_spirv OwnedBinary, cl_program_binary_type Type);
@@ -135,7 +135,7 @@ private:
 
     friend struct Loggers;
 
-    std::vector<Device::ref_ptr_int> m_AssociatedDevices;
+    std::vector<D3DDeviceAndRef> m_AssociatedDevices;
 
     struct CommonOptions
     {
@@ -161,10 +161,10 @@ private:
     struct BuildArgs
     {
         CommonOptions Common;
-        std::vector<Device::ref_ptr_int> BinaryBuildDevices;
+        std::vector<D3DDeviceAndRef> BinaryBuildDevices;
     };
 
-    void AddBuiltinOptions(std::vector<Device::ref_ptr_int> const& devices, CommonOptions& optionsStruct);
+    void AddBuiltinOptions(std::vector<D3DDeviceAndRef> const& devices, CommonOptions& optionsStruct);
     cl_int ParseOptions(const char* optionsStr, CommonOptions& optionsStruct, bool SupportCompilerOptions, bool SupportLinkerOptions);
     cl_int BuildImpl(BuildArgs const& Args);
     cl_int CompileImpl(CompileArgs const& Args);

--- a/include/program.hpp
+++ b/include/program.hpp
@@ -118,6 +118,7 @@ private:
     struct PerDeviceData
     {
         Device* m_Device;
+        D3DDevice *m_D3DDevice;
         cl_build_status m_BuildStatus = CL_BUILD_IN_PROGRESS;
         std::string m_BuildLog;
         unique_spirv m_OwnedBinary;

--- a/include/queue.hpp
+++ b/include/queue.hpp
@@ -9,7 +9,7 @@
 class CommandQueue : public CLChildBase<CommandQueue, Device, cl_command_queue>
 {
 public:
-    CommandQueue(Device& device, Context& context, const cl_queue_properties* properties, bool synthesizedProperties);
+    CommandQueue(D3DDevice& device, Context& context, const cl_queue_properties* properties, bool synthesizedProperties);
 
     friend cl_int CL_API_CALL clGetCommandQueueInfo(cl_command_queue, cl_command_queue_info, size_t, void*, size_t*);
 

--- a/include/queue.hpp
+++ b/include/queue.hpp
@@ -15,6 +15,7 @@ public:
 
     Context& GetContext() const { return m_Context.get(); }
     Device& GetDevice() const { return m_Parent.get(); }
+    D3DDevice &GetD3DDevice() const { return m_D3DDevice; }
 
     void Flush(TaskPoolLock const&, bool flushDevice);
     void QueueTask(Task*, TaskPoolLock const&);
@@ -28,6 +29,7 @@ public:
 
 protected:
     Context::ref_int m_Context;
+    D3DDevice &m_D3DDevice;
 
     std::deque<Task::ref_ptr> m_QueuedTasks;
     std::vector<Task::ref_ptr_int> m_OutstandingTasks;

--- a/include/resources.hpp
+++ b/include/resources.hpp
@@ -46,7 +46,7 @@ public:
     static Resource* CreateSubBuffer(Resource& ParentBuffer, const cl_buffer_region& region, cl_mem_flags flags);
     static Resource* CreateImage(Context& Parent, D3D12TranslationLayer::ResourceCreationArgs& Args, void* pHostPointer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
     static Resource* CreateImage1DBuffer(Resource& ParentBuffer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
-    static Resource *ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_glinterop_export_in &in);
+    static Resource *ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_glinterop_export_in &in, cl_int *error);
 
     UnderlyingResource* GetUnderlyingResource(D3DDevice*);
     void SetActiveDevice(D3DDevice*);

--- a/include/resources.hpp
+++ b/include/resources.hpp
@@ -32,15 +32,15 @@ public:
     static Resource* CreateImage(Context& Parent, D3D12TranslationLayer::ResourceCreationArgs& Args, void* pHostPointer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
     static Resource* CreateImage1DBuffer(Resource& ParentBuffer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
 
-    UnderlyingResource* GetUnderlyingResource(Device*);
+    UnderlyingResource* GetUnderlyingResource(D3DDevice*);
     void SetActiveDevice(Device*);
     UnderlyingResource* GetActiveUnderlyingResource() const { return m_ActiveUnderlying; }
     cl_uint GetMapCount() const { std::lock_guard MapLock(m_MapLock); return m_MapCount; }
 
     void EnqueueMigrateResource(Device* newDevice, Task* triggeringTask, cl_mem_migration_flags flags);
 
-    D3D12TranslationLayer::SRV& GetSRV(Device*);
-    D3D12TranslationLayer::UAV& GetUAV(Device*);
+    D3D12TranslationLayer::SRV& GetSRV(D3DDevice*);
+    D3D12TranslationLayer::UAV& GetUAV(D3DDevice*);
     ~Resource();
 
     void AddMapTask(MapTask*);
@@ -53,9 +53,9 @@ protected:
     std::recursive_mutex m_MultiDeviceLock;
     Device *m_CurrentActiveDevice = nullptr;
     UnderlyingResource *m_ActiveUnderlying = nullptr;
-    std::unordered_map<Device*, UnderlyingResourcePtr> m_UnderlyingMap;
-    std::unordered_map<Device*, D3D12TranslationLayer::SRV> m_SRVs;
-    std::unordered_map<Device*, D3D12TranslationLayer::UAV> m_UAVs;
+    std::unordered_map<D3DDevice*, UnderlyingResourcePtr> m_UnderlyingMap;
+    std::unordered_map<D3DDevice*, D3D12TranslationLayer::SRV> m_SRVs;
+    std::unordered_map<D3DDevice*, D3D12TranslationLayer::UAV> m_UAVs;
 
     std::unique_ptr<byte[]> m_InitialData;
     D3D12TranslationLayer::D3D12_UNORDERED_ACCESS_VIEW_DESC_WRAPPER m_UAVDesc;

--- a/include/resources.hpp
+++ b/include/resources.hpp
@@ -3,9 +3,13 @@
 #pragma once
 
 #include "context.hpp"
+#include <optional>
 
 class MapTask;
 class Task;
+
+struct mesa_glinterop_export_in;
+struct mesa_glinterop_export_out;
 
 class Resource : public CLChildBase<Resource, Context, cl_mem>
 {
@@ -27,10 +31,20 @@ public:
     const cl_image_desc m_Desc;
     D3D12TranslationLayer::ResourceCreationArgs m_CreationArgs;
 
+    struct GLInfo
+    {
+        cl_gl_object_type ObjectType;
+        cl_GLuint ObjectName;
+        cl_GLenum TextureTarget;
+        cl_GLint MipLevel;
+    };
+    std::optional<GLInfo> m_GLInfo;
+
     static Resource* CreateBuffer(Context& Parent, D3D12TranslationLayer::ResourceCreationArgs& Args, void* pHostPointer, cl_mem_flags flags);
     static Resource* CreateSubBuffer(Resource& ParentBuffer, const cl_buffer_region& region, cl_mem_flags flags);
     static Resource* CreateImage(Context& Parent, D3D12TranslationLayer::ResourceCreationArgs& Args, void* pHostPointer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
     static Resource* CreateImage1DBuffer(Resource& ParentBuffer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
+    static Resource *ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_glinterop_export_in &in);
 
     UnderlyingResource* GetUnderlyingResource(D3DDevice*);
     void SetActiveDevice(D3DDevice*);

--- a/include/resources.hpp
+++ b/include/resources.hpp
@@ -37,6 +37,8 @@ public:
         cl_GLuint ObjectName;
         cl_GLenum TextureTarget;
         cl_GLint MipLevel;
+        uint64_t BufferOffset;
+        uint32_t BaseArray;
     };
     std::optional<GLInfo> m_GLInfo;
 
@@ -82,9 +84,9 @@ protected:
     mutable std::mutex m_DestructorLock;
     std::vector<DestructorCallback> m_DestructorCallbacks;
 
-    Resource(Context& Parent, decltype(m_CreationArgs) const& CreationArgs, void* pHostPointer, size_t size, cl_mem_flags flags);
+    Resource(Context& Parent, decltype(m_CreationArgs) const& CreationArgs, void* pHostPointer, size_t size, cl_mem_flags flags, std::optional<GLInfo> glInfo);
     Resource(Resource& ParentBuffer, size_t offset, size_t size, const cl_image_format& image_format, cl_mem_object_type type, cl_mem_flags flags);
-    Resource(Context& Parent, decltype(m_CreationArgs) const& CreationArgs, void* pHostPointer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
+    Resource(Context& Parent, decltype(m_CreationArgs) const& CreationArgs, void* pHostPointer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags, std::optional<GLInfo> glInfo);
 
     static cl_image_desc GetBufferDesc(size_t size, cl_mem_object_type type);
     void UploadInitialData(Task* triggeringTask);

--- a/include/resources.hpp
+++ b/include/resources.hpp
@@ -33,11 +33,11 @@ public:
     static Resource* CreateImage1DBuffer(Resource& ParentBuffer, const cl_image_format& image_format, const cl_image_desc& image_desc, cl_mem_flags flags);
 
     UnderlyingResource* GetUnderlyingResource(D3DDevice*);
-    void SetActiveDevice(Device*);
+    void SetActiveDevice(D3DDevice*);
     UnderlyingResource* GetActiveUnderlyingResource() const { return m_ActiveUnderlying; }
     cl_uint GetMapCount() const { std::lock_guard MapLock(m_MapLock); return m_MapCount; }
 
-    void EnqueueMigrateResource(Device* newDevice, Task* triggeringTask, cl_mem_migration_flags flags);
+    void EnqueueMigrateResource(D3DDevice* newDevice, Task* triggeringTask, cl_mem_migration_flags flags);
 
     D3D12TranslationLayer::SRV& GetSRV(D3DDevice*);
     D3D12TranslationLayer::UAV& GetUAV(D3DDevice*);
@@ -51,7 +51,7 @@ public:
 
 protected:
     std::recursive_mutex m_MultiDeviceLock;
-    Device *m_CurrentActiveDevice = nullptr;
+    D3DDevice *m_CurrentActiveDevice = nullptr;
     UnderlyingResource *m_ActiveUnderlying = nullptr;
     std::unordered_map<D3DDevice*, UnderlyingResourcePtr> m_UnderlyingMap;
     std::unordered_map<D3DDevice*, D3D12TranslationLayer::SRV> m_SRVs;

--- a/include/sampler.hpp
+++ b/include/sampler.hpp
@@ -15,11 +15,11 @@ public:
     };
     Sampler(Context& Parent, Desc const& desc, const cl_sampler_properties *properties);
 
-    D3D12TranslationLayer::Sampler& GetUnderlying(Device*);
+    D3D12TranslationLayer::Sampler& GetUnderlying(D3DDevice*);
 
     const Desc m_Desc;
     const std::vector<cl_sampler_properties> m_Properties;
 private:
     std::mutex m_Lock;
-    std::unordered_map<class Device*, D3D12TranslationLayer::Sampler> m_UnderlyingSamplers;
+    std::unordered_map<class D3DDevice*, D3D12TranslationLayer::Sampler> m_UnderlyingSamplers;
 };

--- a/include/task.hpp
+++ b/include/task.hpp
@@ -183,6 +183,7 @@ public:
         cl_uint Depth;
         cl_ushort FirstArraySlice;
         cl_ushort NumArraySlices;
+        cl_uchar FirstMipLevel;
     };
 
     MapTask(Context& Parent, cl_command_queue command_queue, Resource& resource, cl_map_flags flags, cl_command_type command, Args const& args);

--- a/include/task.hpp
+++ b/include/task.hpp
@@ -73,7 +73,7 @@ class Task : public CLChildBase<Task, Context, cl_event>
 
 public:
     struct DependencyException {};
-    friend class Device;
+    friend class D3DDevice;
     enum class State
     {
         // API-visible states (sorted in reverse order so CL_COMPLETE == CL_SUCCESS == 0)

--- a/include/task.hpp
+++ b/include/task.hpp
@@ -97,9 +97,10 @@ public:
     const cl_command_type m_CommandType;
     const ::ref_ptr_int<class CommandQueue> m_CommandQueue;
     const ::ref_ptr_int<class Device> m_Device;
+    class D3DDevice *const m_D3DDevice;
 
     Task(Context& Parent, cl_command_type command_type, cl_command_queue command_queue);
-    Task(Context& Parent, Device& device);
+    Task(Context& Parent, D3DDevice& device);
     virtual ~Task();
 
     static cl_ulong TimestampToNanoseconds(cl_ulong Ticks, cl_ulong Frequency);

--- a/src/OpenCLOn12.def
+++ b/src/OpenCLOn12.def
@@ -58,6 +58,7 @@ clGetDeviceInfo
 clGetEventInfo
 clGetEventProfilingInfo
 clGetExtensionFunctionAddress
+clGetGLContextInfoKHR
 ; clGetGLObjectInfo
 ; clGetGLTextureInfo
 clGetImageInfo

--- a/src/OpenCLOn12.def
+++ b/src/OpenCLOn12.def
@@ -19,10 +19,10 @@ clCreateBuffer
 clCreateCommandQueue
 clCreateContext
 clCreateContextFromType
-; clCreateFromGLBuffer
-; clCreateFromGLRenderbuffer
-; clCreateFromGLTexture2D
-; clCreateFromGLTexture3D
+clCreateFromGLBuffer
+clCreateFromGLRenderbuffer
+clCreateFromGLTexture2D
+clCreateFromGLTexture3D
 clCreateImage2D
 clCreateImage3D
 clCreateKernel
@@ -30,7 +30,7 @@ clCreateKernelsInProgram
 clCreateProgramWithBinary
 clCreateProgramWithSource
 clCreateSampler
-; clEnqueueAcquireGLObjects
+clEnqueueAcquireGLObjects
 clEnqueueBarrier
 clEnqueueCopyBuffer
 clEnqueueCopyBufferToImage
@@ -43,7 +43,7 @@ clEnqueueNDRangeKernel
 clEnqueueNativeKernel
 clEnqueueReadBuffer
 clEnqueueReadImage
-; clEnqueueReleaseGLObjects
+clEnqueueReleaseGLObjects
 clEnqueueTask
 clEnqueueUnmapMemObject
 clEnqueueWaitForEvents
@@ -59,8 +59,8 @@ clGetEventInfo
 clGetEventProfilingInfo
 clGetExtensionFunctionAddress
 clGetGLContextInfoKHR
-; clGetGLObjectInfo
-; clGetGLTextureInfo
+clGetGLObjectInfo
+clGetGLTextureInfo
 clGetImageInfo
 clGetKernelInfo
 clGetKernelWorkGroupInfo
@@ -102,7 +102,7 @@ clSetUserEventStatus
 
 ; OpenCL 1.2 API
 clCompileProgram
-; clCreateFromGLTexture
+clCreateFromGLTexture
 clCreateImage
 clCreateProgramWithBuiltInKernels
 clCreateSubDevices

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -33,6 +33,10 @@ public:
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_AppContext, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
     }
+    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
+    {
+        return m_ExportObject(m_Display, m_AppContext, &in, &out);
+    }
 
     virtual bool BindContext() final
     {
@@ -152,6 +156,10 @@ public:
         mesa_glinterop_device_info mesaDevInfo = {};
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_AppContext, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
+    }
+    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
+    {
+        return m_ExportObject(m_Display, m_AppContext, &in, &out);
     }
     virtual bool BindContext() final
     {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -298,12 +298,6 @@ D3DDevice& Context::GetD3DDevice(cl_uint i) const noexcept
     return *m_AssociatedDevices[i].second;
 }
 
-bool Context::ValidDeviceForContext(Device& device) const noexcept
-{
-    return std::find_if(m_AssociatedDevices.begin(), m_AssociatedDevices.end(),
-                        [&device](D3DDeviceAndRef const& d) { return d.first.Get() == &device; }) != m_AssociatedDevices.end();
-}
-
 D3DDevice *Context::D3DDeviceForContext(Device& device) const noexcept
 {
     auto iter = std::find_if(m_AssociatedDevices.begin(), m_AssociatedDevices.end(),

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -44,9 +44,9 @@ public:
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_AppContext, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
     }
-    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
+    virtual int GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
     {
-        return m_ExportObject(m_Display, m_AppContext, &in, &out) == MESA_GLINTEROP_SUCCESS;
+        return m_ExportObject(m_Display, m_AppContext, &in, &out);
     }
     virtual bool AcquireResources(std::vector<mesa_glinterop_export_in> &resources, GLsync *sync) final
     {
@@ -177,9 +177,9 @@ public:
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_AppContext, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
     }
-    virtual bool GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
+    virtual int GetResourceData(mesa_glinterop_export_in &in, mesa_glinterop_export_out &out) final
     {
-        return m_ExportObject(m_Display, m_AppContext, &in, &out) == MESA_GLINTEROP_SUCCESS;
+        return m_ExportObject(m_Display, m_AppContext, &in, &out);
     }
     virtual bool AcquireResources(std::vector<mesa_glinterop_export_in> &resources, GLsync *sync) final
     {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -19,13 +19,6 @@ public:
     static std::unique_ptr<GLInteropManager> Create(GLProperties const &glProps);
     virtual ~GLInteropManager() = default;
     virtual bool GetDeviceData(d3d12_interop_device_info &d3d12DevInfo) = 0;
-    d3d12_interop_device_info GetDeviceData()
-    {
-        d3d12_interop_device_info ret = {};
-        [[maybe_unused]] bool success = GetDeviceData(ret);
-        assert(success);
-        return ret;
-    }
 protected:
     void PrepQueryDeviceInfo(mesa_glinterop_device_info &mesaDevInfo,
                              d3d12_interop_device_info &d3d12DevInfo)
@@ -473,7 +466,12 @@ Context::Context(Platform& Platform, std::vector<D3DDeviceAndRef> Devices,
 {
     for (auto& [device, d3ddevice] : m_AssociatedDevices)
     {
-        d3ddevice = &device->InitD3D();
+        d3d12_interop_device_info glInfo = {};
+        if (m_GLInteropManager)
+        {
+            m_GLInteropManager->GetDeviceData(glInfo);
+        }
+        d3ddevice = &device->InitD3D(glInfo.device, glInfo.queue);
     }
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -50,6 +50,7 @@ public:
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_Context, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
     }
+    ~WGLInteropManager() = default;
 
 private:
     const HDC m_Display;
@@ -88,6 +89,7 @@ public:
         PrepQueryDeviceInfo(mesaDevInfo, d3d12DevInfo);
         return m_QueryDeviceInfo(m_Display, m_Context, &mesaDevInfo) == MESA_GLINTEROP_SUCCESS;
     }
+    ~EGLInteropManager() = default;
 
 private:
     const EGLDisplay m_Display;
@@ -116,11 +118,11 @@ std::unique_ptr<GLInteropManager> GLInteropManager::Create(GLProperties const &g
 {
     if (glProps.eglContext)
     {
-        return std::make_unique<EGLInteropManager>(glProps);
+        return std::unique_ptr<GLInteropManager>(new EGLInteropManager(glProps));
     }
     else if (glProps.wglContext)
     {
-        return std::make_unique<WGLInteropManager>(glProps);
+        return std::unique_ptr<GLInteropManager>(new WGLInteropManager(glProps));
     }
     return nullptr;
 }
@@ -483,9 +485,9 @@ Context::~Context()
         callback.m_pfn(this, callback.m_userData);
     }
 
-    for (auto& [device, _] : m_AssociatedDevices)
+    for (auto& [device, d3dDevice] : m_AssociatedDevices)
     {
-        device->ReleaseD3D();
+        device->ReleaseD3D(*d3dDevice);
     }
 }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -77,9 +77,9 @@ private:
         decltype(&wglDeleteContext)> m_MyContext {nullptr, nullptr};
     decltype(&wglMakeCurrent) m_MakeCurrent;
     decltype(&wglGetCurrentContext) m_GetCurrentContext;
-    decltype(&MesaGLInteropWGLQueryDeviceInfo) m_QueryDeviceInfo;
-    decltype(&MesaGLInteropWGLExportObject) m_ExportObject;
-    decltype(&MesaGLInteropWGLFlushObjects) m_FlushObjects;
+    decltype(&wglMesaGLInteropQueryDeviceInfo) m_QueryDeviceInfo;
+    decltype(&wglMesaGLInteropExportObject) m_ExportObject;
+    decltype(&wglMesaGLInteropFlushObjects) m_FlushObjects;
 
     friend class GLInteropManager;
     WGLInteropManager(GLProperties const &glProps)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -413,6 +413,13 @@ std::string Device::GetDeviceName() const
     return name;
 }
 
+LUID Device::GetAdapterLuid() const
+{
+    LUID ret = {};
+    m_spAdapter->GetProperty(DXCoreAdapterProperty::InstanceLuid, &ret);
+    return ret;
+}
+
 void D3DDevice::SubmitTask(Task* task, TaskPoolLock const& lock)
 {
     assert(task->m_CommandType != CL_COMMAND_USER);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -210,6 +210,8 @@ clGetDeviceInfo(cl_device_id    device,
                                                    "cl_khr_byte_addressable_store "
                                                    "cl_khr_il_program "
                                                    "cl_khr_3d_image_writes "
+                                                   "cl_khr_gl_sharing "
+                                                   "cl_khr_gl_event "
         );
 
         case CL_DEVICE_PRINTF_BUFFER_SIZE: return RetValue((size_t)1024 * 1024);

--- a/src/gl_tasks.cpp
+++ b/src/gl_tasks.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "context.hpp"
+#include "task.hpp"
+#include "resources.hpp"
+#include "queue.hpp"
+
+#include <mesa_glinterop.h>
+#include <d3d12_interop_public.h>
+
+#include "gl_tokens.hpp"
+
+class AcquireFromGLTask : public Task
+{
+public:
+    AcquireFromGLTask(Context &Parent, cl_command_type command, cl_command_queue command_queue, std::vector<Resource::ref_ptr_int> resources, GLsync sync)
+        : Task(Parent, command, command_queue)
+        , m_Sync(sync)
+        , m_Resources(std::move(resources))
+    {
+    }
+
+private:
+    void RecordImpl() final
+    {
+        m_Parent->GetGLManager()->SyncWait(m_Sync, m_CommandType == CL_COMMAND_ACQUIRE_GL_OBJECTS);
+    }
+    void MigrateResources() final
+    {
+        for (auto &res : m_Resources)
+        {
+            res->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
+        }
+    }
+    GLsync m_Sync;
+    std::vector<Resource::ref_ptr_int> m_Resources;
+};
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueAcquireGLObjects(cl_command_queue      command_queue,
+                          cl_uint               num_objects,
+                          const cl_mem *        mem_objects,
+                          cl_uint               num_events_in_wait_list,
+                          const cl_event *      event_wait_list,
+                          cl_event *            event) CL_API_SUFFIX__VERSION_1_0
+{
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    CommandQueue& queue = *static_cast<CommandQueue*>(command_queue);
+    Context& context = queue.GetContext();
+    auto ReportError = context.GetErrorReporter();
+    if (!context.GetGLManager())
+    {
+        return ReportError("Context was not created from a GL context", CL_INVALID_CONTEXT);
+    }
+
+    if ((event_wait_list == nullptr) != (num_events_in_wait_list == 0))
+    {
+        return ReportError("If event_wait_list is null, then num_events_in_wait_list must be zero, and vice versa.", CL_INVALID_EVENT_WAIT_LIST);
+    }
+    if ((mem_objects == nullptr) != (num_objects == 0))
+    {
+        return ReportError("If mem_objects is null, then num_objects must be zero, and vice versa.", CL_INVALID_VALUE);
+    }
+
+    try
+    {
+        std::vector<Resource::ref_ptr_int> resources;
+        std::vector<mesa_glinterop_export_in> glResources;
+        resources.reserve(num_objects);
+        glResources.reserve(num_objects);
+        for (cl_uint i = 0; i < num_objects; ++i)
+        {
+            if (!mem_objects[i])
+            {
+                return ReportError("Invalid memory object specific in mem_objects", CL_INVALID_MEM_OBJECT);
+            }
+            Resource &res = *static_cast<Resource *>(mem_objects[i]);
+            if (!res.m_GLInfo)
+            {
+                return ReportError("A memory object was not created from a GL object", CL_INVALID_GL_OBJECT);
+            }
+            resources.emplace_back(&res);
+
+            mesa_glinterop_export_in glResource = {};
+            glResource.version = 1;
+            glResource.target = res.m_GLInfo->TextureTarget;
+            glResource.obj = res.m_GLInfo->ObjectName;
+            glResources.push_back(glResource);
+        }
+
+        // The GL context must either be idle (glFinish), or be bound to this current thread as per cl_khr_gl_event
+        // Either way, this will trigger a flush and return a sync object such that this CL event won't be satisfied
+        // until after the GL commands from this context are complete.
+        GLsync sync = {};
+        context.GetGLManager()->AcquireResources(glResources, &sync);
+
+        std::unique_ptr<Task> task(new AcquireFromGLTask(context, CL_COMMAND_ACQUIRE_GL_OBJECTS, command_queue, std::move(resources), sync));
+
+        auto Lock = g_Platform->GetTaskPoolLock();
+        if (num_events_in_wait_list)
+        {
+            task->AddDependencies(event_wait_list, num_events_in_wait_list, Lock);
+        }
+
+        queue.QueueTask(task.get(), Lock);
+
+        // No more exceptions
+        if (event)
+            *event = task.release();
+        else
+            task.release()->Release();
+    }
+    catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
+    catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
+    catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
+
+    return CL_SUCCESS;
+}
+
+class ReleaseToGLTask : public Task
+{
+public:
+    ReleaseToGLTask(Context &Parent, cl_command_queue command_queue, std::vector<Resource::ref_ptr_int> resources)
+        : Task(Parent, CL_COMMAND_RELEASE_GL_OBJECTS, command_queue)
+        , m_Resources(std::move(resources))
+    {
+        auto glInterop = Parent.GetGLManager();
+        if (glInterop->IsAppContextBoundToThread())
+        {
+            D3D12TranslationLayer::ThrowFailure(m_CommandQueue->GetD3DDevice().GetDevice()->
+                                                CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(m_Fence.ReleaseAndGetAddressOf())));
+            Parent.InsertGLWait(m_Fence.Get(), 1);
+        }
+    }
+
+private:
+    void RecordImpl() final
+    {
+        auto &ImmCtx = m_CommandQueue->GetD3DDevice().ImmCtx();
+        for (auto &res : m_Resources)
+        {
+            ImmCtx.GetResourceStateManager().
+                TransitionResource(res->GetActiveUnderlyingResource(),
+                                   D3D12_RESOURCE_STATE_COMMON,
+                                   D3D12TranslationLayer::COMMAND_LIST_TYPE::GRAPHICS,
+                                   D3D12TranslationLayer::SubresourceTransitionFlags::StateMatchExact |
+                                       D3D12TranslationLayer::SubresourceTransitionFlags::ForceExclusiveState |
+                                       D3D12TranslationLayer::SubresourceTransitionFlags::NotUsedInCommandListIfNoStateChange);
+        }
+        ImmCtx.GetResourceStateManager().ApplyAllResourceTransitions();
+    }
+    void MigrateResources() final
+    {
+        for (auto &res : m_Resources)
+        {
+            res->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
+        }
+    }
+    void OnComplete() final
+    {
+        if (m_Fence)
+        {
+            m_Fence->Signal(1);
+        }
+    }
+    std::vector<Resource::ref_ptr_int> m_Resources;
+    ComPtr<ID3D12Fence> m_Fence;
+};
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReleaseGLObjects(cl_command_queue      command_queue,
+                          cl_uint               num_objects,
+                          const cl_mem *        mem_objects,
+                          cl_uint               num_events_in_wait_list,
+                          const cl_event *      event_wait_list,
+                          cl_event *            event) CL_API_SUFFIX__VERSION_1_0
+{
+    if (!command_queue)
+    {
+        return CL_INVALID_COMMAND_QUEUE;
+    }
+    CommandQueue& queue = *static_cast<CommandQueue*>(command_queue);
+    Context& context = queue.GetContext();
+    auto ReportError = context.GetErrorReporter();
+    if (!context.GetGLManager())
+    {
+        return ReportError("Context was not created from a GL context", CL_INVALID_CONTEXT);
+    }
+
+    if ((event_wait_list == nullptr) != (num_events_in_wait_list == 0))
+    {
+        return ReportError("If event_wait_list is null, then num_events_in_wait_list must be zero, and vice versa.", CL_INVALID_EVENT_WAIT_LIST);
+    }
+    if ((mem_objects == nullptr) != (num_objects == 0))
+    {
+        return ReportError("If mem_objects is null, then num_objects must be zero, and vice versa.", CL_INVALID_VALUE);
+    }
+
+    try
+    {
+        std::vector<Resource::ref_ptr_int> resources;
+        resources.reserve(num_objects);
+        for (cl_uint i = 0; i < num_objects; ++i)
+        {
+            if (!mem_objects[i])
+            {
+                return ReportError("Invalid memory object specific in mem_objects", CL_INVALID_MEM_OBJECT);
+            }
+            Resource &res = *static_cast<Resource *>(mem_objects[i]);
+            if (!res.m_GLInfo)
+            {
+                return ReportError("A memory object was not created from a GL object", CL_INVALID_GL_OBJECT);
+            }
+            resources.emplace_back(&res);
+        }
+
+        std::unique_ptr<Task> task(new ReleaseToGLTask(context, command_queue, std::move(resources)));
+
+        auto Lock = g_Platform->GetTaskPoolLock();
+        if (num_events_in_wait_list)
+        {
+            task->AddDependencies(event_wait_list, num_events_in_wait_list, Lock);
+        }
+
+        queue.QueueTask(task.get(), Lock);
+
+        // No more exceptions
+        if (event)
+            *event = task.release();
+        else
+            task.release()->Release();
+    }
+    catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
+    catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
+    catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
+    catch (Task::DependencyException&) { return ReportError("Context mismatch between command_queue and event_wait_list", CL_INVALID_CONTEXT); }
+
+    return CL_SUCCESS;
+}

--- a/src/gl_tasks.cpp
+++ b/src/gl_tasks.cpp
@@ -160,8 +160,6 @@ clCreateEventFromGLsyncKHR(cl_context context_,
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
     catch (std::exception &e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
-
-    return CL_SUCCESS;
 }
 
 class ReleaseToGLTask : public Task

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -22,7 +22,7 @@ clCreateKernel(cl_program      program_,
     {
         std::lock_guard Lock(program.m_Lock);
         cl_uint DeviceCountWithProgram = 0, DeviceCountWithKernel = 0;
-        for (auto& Device : program.m_AssociatedDevices)
+        for (auto& [Device, _] : program.m_AssociatedDevices)
         {
             auto& BuildData = program.m_BuildData[Device.Get()];
             if (!BuildData ||
@@ -111,7 +111,7 @@ clCreateKernelsInProgram(cl_program     program_,
 
         {
             std::lock_guard Lock(program.m_Lock);
-            for (auto& Device : program.m_AssociatedDevices)
+            for (auto& [Device, _] : program.m_AssociatedDevices)
             {
                 auto& BuildData = program.m_BuildData[Device.Get()];
                 if (!BuildData ||

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -126,12 +126,12 @@ public:
         for (auto& res : m_KernelArgUAVs)
         {
             if (res.Get())
-                res->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+                res->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
         }
         for (auto& res : m_KernelArgSRVs)
         {
             if (res.Get())
-                res->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+                res->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
         }
     }
     void RecordImpl() final;
@@ -232,7 +232,7 @@ public:
         if (kernel.m_Dxil.GetMetadata().printf_uav_id >= 0)
         {
             m_PrintfUAV.Attach(static_cast<Resource*>(clCreateBuffer(&m_Parent.get(), CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR, PrintfBufferSize, (void*)PrintfBufferInitialData, nullptr)));
-            m_PrintfUAV->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+            m_PrintfUAV->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
             m_UAVs[kernel.m_Dxil.GetMetadata().printf_uav_id] = &m_PrintfUAV->GetUAV(&Device);
         }
 

--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -197,7 +197,7 @@ public:
             }
         }
 
-        auto& Device = m_CommandQueue->GetDevice();
+        auto& Device = m_CommandQueue->GetD3DDevice();
 
         D3D12TranslationLayer::ResourceCreationArgs Args = {};
         Args.m_appDesc.m_Subresources = 1;
@@ -232,7 +232,7 @@ public:
         if (kernel.m_Dxil.GetMetadata().printf_uav_id >= 0)
         {
             m_PrintfUAV.Attach(static_cast<Resource*>(clCreateBuffer(&m_Parent.get(), CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR, PrintfBufferSize, (void*)PrintfBufferInitialData, nullptr)));
-            m_PrintfUAV->EnqueueMigrateResource(&Device, this, 0);
+            m_PrintfUAV->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
             m_UAVs[kernel.m_Dxil.GetMetadata().printf_uav_id] = &m_PrintfUAV->GetUAV(&Device);
         }
 
@@ -524,7 +524,7 @@ void ExecuteKernel::RecordImpl()
         throw std::exception("Failed to specialize");
     }
 
-    auto& Device = m_CommandQueue->GetDevice();
+    auto& Device = m_CommandQueue->GetD3DDevice();
     std::transform(m_KernelArgUAVs.begin(), m_KernelArgUAVs.end(), m_UAVs.begin(), [&Device](Resource::ref_ptr_int& resource) { return resource.Get() ? &resource->GetUAV(&Device) : nullptr; });
     std::transform(m_KernelArgSRVs.begin(), m_KernelArgSRVs.end(), m_SRVs.begin(), [&Device](Resource::ref_ptr_int& resource) { return resource.Get() ? &resource->GetSRV(&Device) : nullptr; });
     std::transform(m_KernelArgSamplers.begin(), m_KernelArgSamplers.end(), m_Samplers.begin(), [&Device](Sampler::ref_ptr_int& sampler) { return sampler.Get() ? &sampler->GetUnderlying(&Device) : nullptr; });
@@ -593,7 +593,7 @@ void ExecuteKernel::OnComplete()
 
     if (m_PrintfUAV.Get())
     {
-        auto& Device = m_CommandQueue->GetDevice();
+        auto& Device = m_CommandQueue->GetD3DDevice();
         auto& ImmCtx = Device.ImmCtx();
         auto TranslationResource = m_PrintfUAV->GetUnderlyingResource(&Device);
         D3D12TranslationLayer::MappedSubresource MapRet = {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,10 @@ struct ExtensionTableEntry
 
 static struct ExtensionTableEntry clExtensions[] =
 {
+    // cl_khr_icd
     EXT_FUNC(clIcdGetPlatformIDsKHR),
+
+    // cl_khr_gl_sharing
     EXT_FUNC(clGetGLContextInfoKHR),
     EXT_FUNC(clCreateFromGLBuffer),
     EXT_FUNC(clCreateFromGLTexture),
@@ -41,7 +44,12 @@ static struct ExtensionTableEntry clExtensions[] =
     EXT_FUNC(clEnqueueReleaseGLObjects),
     EXT_FUNC(clGetGLObjectInfo),
     EXT_FUNC(clGetGLTextureInfo),
+
+    // cl_khr_gl_event
     EXT_FUNC(clCreateEventFromGLsyncKHR),
+
+    // cl_khr_il_program
+    EXT_FUNC(clCreateProgramWithILKHR),
 };
 
 static const int clExtensionCount = sizeof(clExtensions) / sizeof(clExtensions[0]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,7 +152,7 @@ cl_icd_dispatch g_DispatchTable
     nullptr, // clReleaseDeviceEXT,
 
     /* cl_khr_gl_event */
-    nullptr, // clCreateEventFromGLsyncKHR,
+    clCreateEventFromGLsyncKHR,
 
     /* OpenCL 1.2 */
     clCreateSubDevices,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,17 @@ struct ExtensionTableEntry
 static struct ExtensionTableEntry clExtensions[] =
 {
     EXT_FUNC(clIcdGetPlatformIDsKHR),
+    EXT_FUNC(clGetGLContextInfoKHR),
+    EXT_FUNC(clCreateFromGLBuffer),
+    EXT_FUNC(clCreateFromGLTexture),
+    EXT_FUNC(clCreateFromGLTexture2D),
+    EXT_FUNC(clCreateFromGLTexture3D),
+    EXT_FUNC(clCreateFromGLRenderbuffer),
+    EXT_FUNC(clEnqueueAcquireGLObjects),
+    EXT_FUNC(clEnqueueReleaseGLObjects),
+    EXT_FUNC(clGetGLObjectInfo),
+    EXT_FUNC(clGetGLTextureInfo),
+    EXT_FUNC(clCreateEventFromGLsyncKHR),
 };
 
 static const int clExtensionCount = sizeof(clExtensions) / sizeof(clExtensions[0]);
@@ -47,6 +58,24 @@ clGetExtensionFunctionAddress(const char *name)
     }
 
     return nullptr;
+}
+
+/* Extension function access
+*
+* Returns the extension function address for the given function name,
+* or NULL if a valid function can not be found.  The client must
+* check to make sure the address is not NULL, before using or
+* calling the returned function address.
+*/
+extern CL_API_ENTRY void * CL_API_CALL
+clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
+                                         const char *   func_name) CL_API_SUFFIX__VERSION_1_2
+{
+    if (platform != g_Platform)
+    {
+        return nullptr;
+    }
+    return clGetExtensionFunctionAddress(func_name);
 }
 
 cl_icd_dispatch g_DispatchTable

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,14 +118,14 @@ cl_icd_dispatch g_DispatchTable
     clEnqueueWaitForEvents,
     clEnqueueBarrier,
     clGetExtensionFunctionAddress,
-    nullptr, // clCreateFromGLBuffer,
-    nullptr, // clCreateFromGLTexture2D,
-    nullptr, // clCreateFromGLTexture3D,
-    nullptr, // clCreateFromGLRenderbuffer,
-    nullptr, // clGetGLObjectInfo,
-    nullptr, // clGetGLTextureInfo,
-    nullptr, // clEnqueueAcquireGLObjects,
-    nullptr, // clEnqueueReleaseGLObjects,
+    clCreateFromGLBuffer,
+    clCreateFromGLTexture2D,
+    clCreateFromGLTexture3D,
+    clCreateFromGLRenderbuffer,
+    clGetGLObjectInfo,
+    clGetGLTextureInfo,
+    clEnqueueAcquireGLObjects,
+    clEnqueueReleaseGLObjects,
     clGetGLContextInfoKHR,
 
     /* cl_khr_d3d10_sharing */
@@ -170,7 +170,7 @@ cl_icd_dispatch g_DispatchTable
     clEnqueueMarkerWithWaitList,
     clEnqueueBarrierWithWaitList,
     clGetExtensionFunctionAddressForPlatform,
-    nullptr, // clCreateFromGLTexture,
+    clCreateFromGLTexture,
 
     /* cl_khr_d3d11_sharing */
     nullptr, // clGetDeviceIDsFromD3D11KHR,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,7 @@ cl_icd_dispatch g_DispatchTable
     nullptr, // clGetGLTextureInfo,
     nullptr, // clEnqueueAcquireGLObjects,
     nullptr, // clEnqueueReleaseGLObjects,
-    nullptr, // clGetGLContextInfoKHR,
+    clGetGLContextInfoKHR,
 
     /* cl_khr_d3d10_sharing */
     nullptr, // clGetDeviceIDsFromD3D10KHR,

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -173,17 +173,6 @@ TaskPoolLock Platform::GetTaskPoolLock()
     return lock;
 }
 
-void Platform::FlushAllDevices(TaskPoolLock const& Lock)
-{
-    for (auto& device : m_Devices)
-    {
-        if (auto &d3dDevice = device->D3DDevice())
-        {
-            d3dDevice->Flush(Lock);
-        }
-    }
-}
-
 void Platform::DeviceInit()
 {
     std::lock_guard Lock(m_ModuleLock);
@@ -277,16 +266,13 @@ void Platform::UnloadCompiler()
 bool Platform::AnyD3DDevicesExist() const noexcept
 {
     return std::any_of(m_Devices.begin(), m_Devices.end(), 
-                       [](std::unique_ptr<Device> const& dev) { return dev->D3DDevice().has_value(); });
+                       [](std::unique_ptr<Device> const& dev) { return dev->HasD3DDevice(); });
 }
 
 void Platform::CloseCaches()
 {
     for (auto& device : m_Devices)
     {
-        if (auto &d3dDevice = device->D3DDevice())
-        {
-            d3dDevice->GetShaderCache().Close();
-        }
+        device->CloseCaches();
     }
 }

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -58,6 +58,8 @@ clGetPlatformInfo(cl_platform_id   platform,
             { CL_MAKE_VERSION(1, 0, 0), "cl_khr_byte_addressable_store" },
             { CL_MAKE_VERSION(1, 0, 0), "cl_khr_il_program" },
             { CL_MAKE_VERSION(1, 0, 0), "cl_khr_3d_image_writes" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_gl_sharing" },
+            { CL_MAKE_VERSION(1, 0, 0), "cl_khr_gl_event" },
         };
         return CopyOutParameter(extensions, param_value_size, param_value, param_value_size_ret);
     }

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -177,9 +177,9 @@ void Platform::FlushAllDevices(TaskPoolLock const& Lock)
 {
     for (auto& device : m_Devices)
     {
-        if (device->GetDevice())
+        if (auto &d3dDevice = device->D3DDevice())
         {
-            device->Flush(Lock);
+            d3dDevice->Flush(Lock);
         }
     }
 }
@@ -276,16 +276,17 @@ void Platform::UnloadCompiler()
 
 bool Platform::AnyD3DDevicesExist() const noexcept
 {
-    return std::any_of(m_Devices.begin(), m_Devices.end(), [](auto& dev) { return dev->GetDevice(); });
+    return std::any_of(m_Devices.begin(), m_Devices.end(), 
+                       [](std::unique_ptr<Device> const& dev) { return dev->D3DDevice().has_value(); });
 }
 
 void Platform::CloseCaches()
 {
     for (auto& device : m_Devices)
     {
-        if (device->GetDevice())
+        if (auto &d3dDevice = device->D3DDevice())
         {
-            device->GetShaderCache().Close();
+            d3dDevice->GetShaderCache().Close();
         }
     }
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -209,6 +209,14 @@ clCreateProgramWithIL(cl_context    context_,
     catch (std::exception & e) { return ReportError(e.what(), CL_OUT_OF_RESOURCES); }
     catch (_com_error&) { return ReportError(nullptr, CL_OUT_OF_RESOURCES); }
 }
+extern CL_API_ENTRY cl_program CL_API_CALL
+clCreateProgramWithILKHR(cl_context    context,
+                         const void*   il,
+                         size_t        length,
+                         cl_int*       errcode_ret)
+{
+    return clCreateProgramWithIL(context, il, length, errcode_ret);
+}
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 clRetainProgram(cl_program program) CL_API_SUFFIX__VERSION_1_0

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -1049,7 +1049,7 @@ cl_int Program::BuildImpl(BuildArgs const& Args)
     if (!m_Source.empty() || !m_IL.empty())
     {
         auto& BuildData = Args.Common.BuildData;
-        pCompiler->Initialize(BuildData->m_Device->GetShaderCache());
+        pCompiler->Initialize(BuildData->m_Device->D3DDevice()->GetShaderCache());
 
         Logger loggers(m_Lock, BuildData->m_BuildLog);
         unique_spirv compiledObject;
@@ -1095,7 +1095,7 @@ cl_int Program::BuildImpl(BuildArgs const& Args)
     }
     else
     {
-        pCompiler->Initialize(Args.BinaryBuildDevices[0]->GetShaderCache());
+        pCompiler->Initialize(Args.BinaryBuildDevices[0]->D3DDevice()->GetShaderCache());
 
         std::lock_guard Lock(m_Lock);
         for (auto& device : Args.BinaryBuildDevices)
@@ -1134,7 +1134,7 @@ cl_int Program::CompileImpl(CompileArgs const& Args)
     cl_int ret = CL_SUCCESS;
     auto& BuildData = Args.Common.BuildData;
     auto pCompiler = g_Platform->GetCompiler();
-    pCompiler->Initialize(BuildData->m_Device->GetShaderCache());
+    pCompiler->Initialize(BuildData->m_Device->D3DDevice()->GetShaderCache());
     Logger loggers(m_Lock, BuildData->m_BuildLog);
 
     unique_spirv object;
@@ -1195,7 +1195,7 @@ cl_int Program::LinkImpl(LinkArgs const& Args)
 
     for (auto& Device : m_AssociatedDevices)
     {
-        pCompiler->Initialize(Device->GetShaderCache());
+        pCompiler->Initialize(Device->D3DDevice()->GetShaderCache());
 
         link_args.objs.clear();
         for (cl_uint i = 0; i < Args.LinkPrograms.size(); ++i)
@@ -1251,7 +1251,7 @@ void Program::PerDeviceData::CreateKernels(Program& program)
         return;
 
     auto pCompiler = g_Platform->GetCompiler();
-    pCompiler->Initialize(m_Device->GetShaderCache());
+    pCompiler->Initialize(m_Device->D3DDevice()->GetShaderCache());
 
     auto& kernels = m_OwnedBinary->GetKernelInfo();
     Logger loggers(program.m_Lock, m_BuildLog);

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -235,6 +235,7 @@ static bool IsProfile(const cl_queue_properties* properties)
 CommandQueue::CommandQueue(Device& device, Context& context, const cl_queue_properties* properties, bool synthesizedProperties)
     : CLChildBase(device)
     , m_Context(context)
+    , m_D3DDevice(*device.D3DDevice())
     , m_Properties(PropertiesToVector(properties))
     , m_bOutOfOrder(IsOutOfOrder(properties))
     , m_bProfile(IsProfile(properties))
@@ -248,11 +249,11 @@ void CommandQueue::Flush(TaskPoolLock const& lock, bool flushDevice)
     {
         m_OutstandingTasks.emplace_back(m_QueuedTasks.front().Get());
         m_QueuedTasks.pop_front();
-        m_Parent->SubmitTask(m_OutstandingTasks.back().Get(), lock);
+        m_D3DDevice.SubmitTask(m_OutstandingTasks.back().Get(), lock);
     }
     if (flushDevice)
     {
-        m_Parent->Flush(lock);
+        m_D3DDevice.Flush(lock);
     }
 }
 

--- a/src/resource_tasks.cpp
+++ b/src/resource_tasks.cpp
@@ -144,7 +144,7 @@ private:
 
     void MigrateResources() final
     {
-        m_Target->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Target->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final;
     void OnComplete() final
@@ -698,7 +698,7 @@ private:
 
     void MigrateResources() final
     {
-        m_Target->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Target->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final;
     void OnComplete() final
@@ -897,7 +897,7 @@ private:
 
     void MigrateResources() final
     {
-        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final;
     void OnComplete() final
@@ -1380,8 +1380,8 @@ private:
 
     void MigrateResources() final
     {
-        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
-        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
+        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final
     {
@@ -1694,8 +1694,8 @@ private:
 
     void MigrateResources() final
     {
-        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
-        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
+        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final;
     void OnComplete() final
@@ -2056,10 +2056,10 @@ private:
     }
     void MigrateResources() final
     {
-        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
-        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_Source->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
+        m_Dest->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
         if (m_Temp.Get())
-            m_Temp->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+            m_Temp->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
     }
     void RecordImpl() final
     {
@@ -2359,7 +2359,7 @@ void MapTask::OnComplete()
 
 void MapTask::MigrateResources()
 {
-    m_Resource.EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+    m_Resource.EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
 }
 
 class MapUseHostPtrResourceTask : public MapTask
@@ -2509,7 +2509,7 @@ public:
             m_MappableResource.Attach(Resource::CreateImage(Parent, Args, nullptr, resource.m_Format, NewDesc, stagingFlags));
         }
 
-        m_MappableResource->EnqueueMigrateResource(&m_CommandQueue->GetDevice(), this, 0);
+        m_MappableResource->EnqueueMigrateResource(&m_CommandQueue->GetD3DDevice(), this, 0);
         auto UnderlyingMapArgs = args;
         UnderlyingMapArgs.SrcX = 0;
         UnderlyingMapArgs.SrcY = 0;

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -606,7 +606,7 @@ clGetSupportedImageFormats(cl_context           context_,
             for (cl_uint device = 0; device < context.GetDeviceCount(); ++device)
             {
                 D3D12_FEATURE_DATA_FORMAT_SUPPORT Support = { (DXGI_FORMAT)i };
-                if (FAILED(context.GetDevice(device).D3DDevice()->GetDevice()->CheckFeatureSupport(
+                if (FAILED(context.GetD3DDevice(device).GetDevice()->CheckFeatureSupport(
                     D3D12_FEATURE_FORMAT_SUPPORT, &Support, sizeof(Support))))
                 {
                     return false;
@@ -704,7 +704,7 @@ clGetMemObjectInfo(cl_mem           memobj,
             return RetValue(resource.m_Desc.image_width);
         auto Underlying = resource.GetActiveUnderlyingResource();
         if (!Underlying)
-            Underlying = resource.GetUnderlyingResource(&*resource.m_Parent->GetDevice(0).D3DDevice());
+            Underlying = resource.GetUnderlyingResource(&resource.m_Parent->GetD3DDevice(0));
         return RetValue((size_t)Underlying->GetResourceSize()); // TODO: GetResourceAllocationInfo instead?
     }
     case CL_MEM_HOST_PTR: return RetValue(resource.m_pHostPointer);
@@ -788,10 +788,10 @@ auto Resource::GetUnderlyingResource(D3DDevice* device) -> UnderlyingResource*
     return Entry.get();
 }
 
-void Resource::SetActiveDevice(Device* device)
+void Resource::SetActiveDevice(D3DDevice* device)
 {
     std::lock_guard Lock(m_MultiDeviceLock);
-    m_ActiveUnderlying = GetUnderlyingResource(&*device->D3DDevice());
+    m_ActiveUnderlying = GetUnderlyingResource(device);
     m_CurrentActiveDevice = device;
 }
 

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -1170,13 +1170,13 @@ Resource *Resource::ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_g
 
     cl_image_desc imageDesc = {};
     imageDesc.image_array_size = out.view_numlayers ?
-        out.view_numlayers : Args.m_appDesc.m_ArraySize;
+        out.view_numlayers : Args.m_appDesc.m_ArraySize - (out.view_minlayer + CubeFaceArrayOffset(in.target));
     imageDesc.image_depth = Args.m_desc12.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D ?
         (Args.m_desc12.DepthOrArraySize >> out.view_minlevel) : 1;
     imageDesc.image_height = Args.m_desc12.Height >> out.view_minlevel;
     imageDesc.image_width = Args.m_desc12.Width >> out.view_minlevel;
     imageDesc.num_mip_levels = out.view_numlevels ? 
-        out.view_numlevels : Args.m_appDesc.m_MipLevels;
+        out.view_numlevels : Args.m_appDesc.m_MipLevels - out.view_minlevel;
     imageDesc.num_samples = Args.m_desc12.SampleDesc.Count;
     imageDesc.image_type = CLTypeFromGLType(in.target);
     if (!imageDesc.image_type)

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -664,7 +664,7 @@ clGetSupportedImageFormats(cl_context           context_,
         if (!IsSupported)
             continue;
 
-        cl_image_format format = GetCLImageFormatForDXGIFormat((DXGI_FORMAT)i);
+        cl_image_format format = GetCLImageFormatForDXGIFormat((DXGI_FORMAT)i, 0);
         if (format.image_channel_data_type != 0)
         {
             if (NumFormats < num_entries && image_formats)
@@ -1172,7 +1172,12 @@ Resource *Resource::ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_g
         return nullptr;
     }
 
-    cl_image_format format = GetCLImageFormatForDXGIFormat(Args.m_desc12.Format);
+    cl_image_format format = GetCLImageFormatForDXGIFormat(Args.m_desc12.Format, out.internal_format);
+    if (format.image_channel_data_type == 0)
+    {
+        // Couldn't infer a CL format to use
+        return nullptr;
+    }
 
     Resource::GLInfo glInfo = {};
     glInfo.TextureTarget = in.target;

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -1151,10 +1151,9 @@ Resource *Resource::ImportGLResource(Context &Parent, cl_mem_flags flags, mesa_g
     Args.m_appDesc.m_Subresources = Args.m_appDesc.m_SubresourcesPerPlane =
         Args.m_appDesc.m_MipLevels * Args.m_appDesc.m_ArraySize;
     d3d12.resource->GetHeapProperties(&Args.m_heapDesc.Properties, &Args.m_heapDesc.Flags);
-    Args.m_PrivateCreateFn = [&](D3D12TranslationLayer::ResourceCreationArgs const &, ID3D12SwapChainAssistant *, ID3D12Resource **ppOut)
+    Args.m_PrivateCreateFn = [res = ComPtr<ID3D12Resource>(d3d12.resource)](D3D12TranslationLayer::ResourceCreationArgs const &, ID3D12SwapChainAssistant *, ID3D12Resource **ppOut) mutable
     {
-        d3d12.resource->AddRef();
-        *ppOut = d3d12.resource;
+        *ppOut = res.Detach();
     };
 
     cl_image_desc imageDesc = {};

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -37,7 +37,7 @@ Sampler::Sampler(Context& Parent, Desc const& desc, const cl_sampler_properties 
 {
 }
 
-D3D12TranslationLayer::Sampler& Sampler::GetUnderlying(Device* device)
+D3D12TranslationLayer::Sampler& Sampler::GetUnderlying(D3DDevice* device)
 {
     std::lock_guard Lock(m_Lock);
     auto iter = m_UnderlyingSamplers.find(device);

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -330,20 +330,6 @@ clEnqueueSVMMigrateMem(cl_command_queue         command_queue,
     return static_cast<CommandQueue*>(command_queue)->GetContext().GetErrorReporter()("Platform does not support SVM", CL_INVALID_OPERATION);
 }
 
-/* Extension function access
- *
- * Returns the extension function address for the given function name,
- * or NULL if a valid function can not be found.  The client must
- * check to make sure the address is not NULL, before using or
- * calling the returned function address.
- */
-extern CL_API_ENTRY void * CL_API_CALL
-clGetExtensionFunctionAddressForPlatform(cl_platform_id platform,
-    const char *   func_name) CL_API_SUFFIX__VERSION_1_2
-{
-    return nullptr;
-}
-
 /* Deprecated OpenCL 1.1 APIs */
 
 extern CL_API_ENTRY CL_API_PREFIX__VERSION_1_1_DEPRECATED cl_int CL_API_CALL

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -42,7 +42,7 @@ clSetDefaultDeviceCommandQueue(cl_context           context_,
         return ReportError("Device must not be null", CL_INVALID_DEVICE);
     }
     Device& device = *static_cast<Device*>(device_);
-    if (!context.ValidDeviceForContext(device))
+    if (!context.D3DDeviceForContext(device))
     {
         return ReportError("Device not valid for this context", CL_INVALID_DEVICE);
     }
@@ -131,7 +131,7 @@ clCreateProgramWithBuiltInKernels(cl_context            context_,
         {
             return ReportError("Device list must not contain null entries", CL_INVALID_DEVICE);
         }
-        if (!context.ValidDeviceForContext(*static_cast<Device*>(device_list[i])))
+        if (!context.D3DDeviceForContext(*static_cast<Device*>(device_list[i])))
         {
             return ReportError("Device list contains device that's invalid for context", CL_INVALID_DEVICE);
         }

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -502,10 +502,13 @@ void Task::AddDependencies(const cl_event* event_wait_list, cl_uint num_events_i
                 {
                     throw DependencyException {};
                 }
-                auto insertRet = task->m_TasksWaitingOnThis.insert(this);
-                if (insertRet.second)
+                if ((cl_int)task->GetState() > CL_COMPLETE)
                 {
-                    m_TasksToWaitOn.emplace_back(task);
+                    auto insertRet = task->m_TasksWaitingOnThis.insert(this);
+                    if (insertRet.second)
+                    {
+                        m_TasksToWaitOn.emplace_back(task);
+                    }
                 }
             }
         }

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -180,11 +180,7 @@ clSetUserEventStatus(cl_event   event,
         e.Complete(execution_status, Lock);
         for (cl_uint i = 0; i < context.GetDeviceCount(); ++i)
         {
-            auto &d3dDeviceOpt = context.GetDevice(i).D3DDevice();
-            if (d3dDeviceOpt)
-            {
-                d3dDeviceOpt->Flush(Lock);
-            }
+            context.GetD3DDevice(i).Flush(Lock);
         }
     }
     catch (std::bad_alloc &) { return ReportError(nullptr, CL_OUT_OF_HOST_MEMORY); }
@@ -449,6 +445,7 @@ Task::Task(Context& Parent, cl_command_type command_type, cl_command_queue comma
     : CLChildBase(Parent)
     , m_CommandQueue(static_cast<CommandQueue*>(command_queue))
     , m_Device(command_queue ? &m_CommandQueue->GetDevice() : nullptr)
+    , m_D3DDevice(command_queue ? &m_CommandQueue->GetD3DDevice() : nullptr)
     , m_CommandType(command_type)
 {
     if (m_CommandQueue.Get() && m_CommandQueue->m_bProfile)
@@ -459,9 +456,10 @@ Task::Task(Context& Parent, cl_command_type command_type, cl_command_queue comma
     }
 }
 
-Task::Task(Context& Parent, Device& device)
+Task::Task(Context& Parent, D3DDevice& device)
     : CLChildBase(Parent)
-    , m_Device(&device)
+    , m_Device(&device.GetParent())
+    , m_D3DDevice(&device)
     , m_CommandType(0)
 {
 }
@@ -599,20 +597,20 @@ void Task::Complete(cl_int error, TaskPoolLock const& lock)
 
     if (m_StartTimestamp || m_StopTimestamp)
     {
-        assert(m_CommandQueue.Get());
-        UINT64 Frequency = m_CommandQueue->GetD3DDevice().GetTimestampFrequency();
+        assert(m_CommandQueue.Get() && m_D3DDevice);
+        UINT64 Frequency = m_D3DDevice->GetTimestampFrequency();
         UINT64 GPUTimestamp;
         if (m_StartTimestamp &&
             m_StartTimestamp->GetData(&GPUTimestamp, sizeof(GPUTimestamp), true, false))
         {
             GetTimestamp(CL_PROFILING_COMMAND_START) =
-                TimestampToNanoseconds(GPUTimestamp, Frequency) + m_Device->D3DDevice()->GPUToQPCTimestampOffset();
+                TimestampToNanoseconds(GPUTimestamp, Frequency) + m_D3DDevice->GPUToQPCTimestampOffset();
         }
         if (m_StopTimestamp &&
             m_StopTimestamp->GetData(&GPUTimestamp, sizeof(GPUTimestamp), true, false))
         {
             GetTimestamp(CL_PROFILING_COMMAND_END) =
-                TimestampToNanoseconds(GPUTimestamp, Frequency) + m_Device->D3DDevice()->GPUToQPCTimestampOffset();
+                TimestampToNanoseconds(GPUTimestamp, Frequency) + m_D3DDevice->GPUToQPCTimestampOffset();
         }
     }
 
@@ -635,7 +633,7 @@ void Task::Complete(cl_int error, TaskPoolLock const& lock)
     {
         for (auto& task : m_TasksWaitingOnThis)
         {
-            assert(task->m_CommandQueue.Get() || task->m_Device.Get());
+            assert(task->m_CommandQueue.Get() || task->m_D3DDevice);
 
             auto newEnd = std::remove_if(task->m_TasksToWaitOn.begin(), task->m_TasksToWaitOn.end(),
                 [this](ref_ptr_int const& p) { return p.Get() == this; });
@@ -645,7 +643,7 @@ void Task::Complete(cl_int error, TaskPoolLock const& lock)
             if (task->m_TasksToWaitOn.empty() &&
                 task->m_State == State::Submitted)
             {
-                task->m_Device->D3DDevice()->ReadyTask(task.Get(), lock);
+                task->m_D3DDevice->ReadyTask(task.Get(), lock);
             }
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,4 +12,5 @@ file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
 file(GLOB INC *.h *.hpp)
 
 add_executable(openclon12test ${SRC} ${INC})
+target_include_directories(openclon12test PRIVATE ../include)
 target_link_libraries(openclon12test openclon12 gtest_main opengl32 gdi32 user32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,4 +12,4 @@ file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
 file(GLOB INC *.h *.hpp)
 
 add_executable(openclon12test ${SRC} ${INC})
-target_link_libraries(openclon12test openclon12 gtest_main)
+target_link_libraries(openclon12test openclon12 gtest_main opengl32 gdi32 user32)

--- a/test/openclon12test.cpp
+++ b/test/openclon12test.cpp
@@ -464,6 +464,11 @@ TEST(OpenCLOn12, GLInterop)
               clGetGLContextInfoKHR(context_props, CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR,
                                     sizeof(glDevice), &glDevice, nullptr));
     EXPECT_NE(glDevice, nullptr);
+    {
+        cl::Context context(cl::Device(glDevice), context_props);
+    }
+
+    wglMakeCurrent(nullptr, nullptr);
     cl::Context context(cl::Device(glDevice), context_props);
 }
 


### PR DESCRIPTION
This passes the CL CTS for GL sharing.

This exposes `cl_khr_gl_sharing` and `cl_khr_gl_event`. These extensions will only actually work when paired with GLOn12 from Mesa, either through WGL or EGL, and only when Mesa is built with the still-in-review https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19242.

As far as implementation details, nothing too crazy. Mesa exports raw D3D12 device, queue, and resources which we then import into CL. Some annoying pieces to note:
* This can import faces of a cubemap, which means that an image can now have a nonzero base array index.
* This can import mip levels from a mipped resource. Mips were something that was ignored for now, so this adjusts subresource index computation all over the place.
* To be able to get at the GL/WGL/EGL functions to do the exporting, sometimes a context needs to be current. This can be a pain. Similarly, to be able to call the functions to make `clEnqueueAcquireGLObjects` and `clCreateEventFromGLsyncKHR` work, a context needs to be current, but those are done from worker threads, so we need our own context.

This also fixes the problem with `cl_khr_il_program` that it wasn't exposed through `clGetExtensionFunctionAddress`\[forPlatform\] while exposing the new GL functions.