### PR TITLE
A few bugfixes and a performance optimization

### DIFF
--- a/include/device.hpp
+++ b/include/device.hpp
@@ -83,6 +83,7 @@ public:
 
     bool HasD3DDevice() const noexcept { return !m_D3DDevices.empty(); }
     void CloseCaches();
+    void FlushAllDevices(TaskPoolLock const& Lock);
 
 protected:
     void CacheCaps(std::lock_guard<std::mutex> const&, ComPtr<ID3D12Device> spDevice = {});

--- a/include/device.hpp
+++ b/include/device.hpp
@@ -39,7 +39,7 @@ protected:
     friend class Device;
 
     void ExecuteTasks(Submission& tasks);
-    unsigned m_ContextCount = 0;
+    unsigned m_ContextCount = 1;
     const bool m_IsImportedDevice;
 
     Device &m_Parent;

--- a/include/platform.hpp
+++ b/include/platform.hpp
@@ -126,6 +126,7 @@ public:
     void UnloadCompiler();
 
     TaskPoolLock GetTaskPoolLock();
+    void FlushAllDevices(TaskPoolLock const& Lock);
 
     bool AnyD3DDevicesExist() const noexcept;
     void CloseCaches();

--- a/include/program.hpp
+++ b/include/program.hpp
@@ -42,6 +42,7 @@ public:
 
     struct SpecializationKey
     {
+        D3DDevice const* Device;
         union
         {
             struct
@@ -67,9 +68,9 @@ public:
                 unsigned Padding : 27;
             } SamplerArgData;
         } Args[1];
-        static std::unique_ptr<SpecializationKey> Allocate(CompiledDxil::Configuration const& conf);
+        static std::unique_ptr<SpecializationKey> Allocate(D3DDevice const* Device, CompiledDxil::Configuration const& conf);
     private:
-        SpecializationKey(CompiledDxil::Configuration const& conf);
+        SpecializationKey(D3DDevice const* Device, CompiledDxil::Configuration const& conf);
     };
     struct SpecializationKeyHash
     {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -501,7 +501,8 @@ void D3DDevice::ReadyTask(Task* task, TaskPoolLock const& lock)
     assert(task->m_TasksToWaitOn.empty());
 
     task->MigrateResources();
-    if (!task->m_TasksToWaitOn.empty())
+    if (!task->m_TasksToWaitOn.empty() ||
+        task->GetState() != Task::State::Submitted)
     {
         // Need to wait for resources to migrate.
         // Once the migration is done, this task will be readied for real

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -175,6 +175,14 @@ TaskPoolLock Platform::GetTaskPoolLock()
     return lock;
 }
 
+void Platform::FlushAllDevices(TaskPoolLock const& Lock)
+{
+    for (auto &device : m_Devices)
+    {
+        device->FlushAllDevices(Lock);
+    }
+}
+
 void Platform::DeviceInit()
 {
     std::lock_guard Lock(m_ModuleLock);

--- a/src/resource_migrate.cpp
+++ b/src/resource_migrate.cpp
@@ -24,14 +24,15 @@ public:
     {
     }
 
-    void MigrateResources() final {}
-    void RecordImpl() final
+    void MigrateResources() final
     {
         if (!m_ToCrossAdapter)
         {
             m_Resource.SetActiveDevice(m_D3DDevice);
         }
-
+    }
+    void RecordImpl() final
+    {
         m_ImmCtx.GetResourceStateManager().TransitionResource(
             m_Resource.GetUnderlyingResource(m_D3DDevice),
             m_ToCrossAdapter ? D3D12_RESOURCE_STATE_COPY_SOURCE : D3D12_RESOURCE_STATE_COPY_DEST);


### PR DESCRIPTION
We can get a pretty decent perf win by batching tasks that only depend on each other into the same D3D command list. Previously we followed a strict state machine model where a task went through the following stages:
1. Queued (submitted to a queue)
2. Submitted to the device (the queue was flushed)
3. Ready (all dependencies have completed)
4. Running (recorded into a command list and submitted to the device)
5. Complete (the CPU has been notified that the work is done)

This change adjusts the model slightly, modifying stage 3. A task can now be moved into the ready state as long as all dependent tasks are on the same device, and *ready* - then we'll batch together larger groups of ready tasks (e.g. an entire flushed command queue) instead of doing a full CPU -> GPU -> CPU round trip for each independent work item from an in-order queue.

Technically, this violates the OpenCL API spec for [events](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#event-objects):
> [CL_RUNNING](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_RUNNING): Indicates that the device has started executing this command. In order for the execution status of an enqueued command to change from [CL_SUBMITTED](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_SUBMITTED) to [CL_RUNNING](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_RUNNING), all events that this command is waiting on must have completed successfully i.e. their execution status must be [CL_COMPLETE](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_COMPLETE).

We'll end up marking an event as `CL_RUNNING` even if its dependences are also only `CL_RUNNING` and not `CL_COMPLETE`, because we don't have fine-grained tracking of work within a command list, so we can't be notified as the GPU moves from one task to the next if they were batched together. The other option would be to defer marking *any* event as running, and only upon completion, iterate through all events and in sequence mark them as running and then complete, but that seems even worse. Regardless, the CL CTS for events didn't seem to mind this behavior.

There's also a couple bugfixes in here for a use-after-free/leak and a multi-device regression.