### PR TITLE
Inherit ShaderModel from the device, and initialize

### DIFF
--- a/src/kernel_tasks.cpp
+++ b/src/kernel_tasks.cpp
@@ -241,6 +241,7 @@ public:
         CompiledDxil::Configuration config = {};
         config.lower_int64 = true;
         config.lower_int16 = !m_Device->SupportsInt16();
+        config.shader_model = Device.GetParent().m_ShaderModel;
         config.support_global_work_id_offsets = std::any_of(std::begin(offset), std::end(offset), [](cl_uint v) { return v != 0; });
         config.support_work_group_id_offsets = numIterations != 1;
         std::copy(std::begin(localSize), std::end(localSize), config.local_size);


### PR DESCRIPTION
Currently config.shader_model is not initialized, or initialized to 0. This makes CLon12 choose the highest possible Shader model, currently 6.7. I encountered a case that the driver doesn't support 6.5 (only supports 6.2) so it fails to create d3d12 device. This patch fixes it by inherits shadermodel version from the device.
