### PR TITLE
Rework local size computation

### DIFF
--- a/include/device.hpp
+++ b/include/device.hpp
@@ -78,6 +78,14 @@ public:
     std::string GetDeviceName() const;
     LUID GetAdapterLuid() const;
     D3D_SHADER_MODEL GetShaderModel() const { return m_ShaderModel; }
+    std::pair<cl_uint, cl_uint> GetWaveSizes() const
+    {
+        if (!m_D3D12Options1.WaveOps)
+        {
+            return { 32, 64 };
+        }
+        return { m_D3D12Options1.WaveLaneCountMin, m_D3D12Options1.WaveLaneCountMax };
+    }
 
     D3DDevice &InitD3D(ID3D12Device *device = nullptr, ID3D12CommandQueue *queue = nullptr);
     void ReleaseD3D(D3DDevice &device);
@@ -97,6 +105,7 @@ protected:
     std::mutex m_InitLock;
     bool m_CapsValid = false;
     D3D12_FEATURE_DATA_D3D12_OPTIONS m_D3D12Options = {};
+    D3D12_FEATURE_DATA_D3D12_OPTIONS1 m_D3D12Options1 = {};
     D3D12_FEATURE_DATA_D3D12_OPTIONS4 m_D3D12Options4 = {};
     D3D12_FEATURE_DATA_ARCHITECTURE m_Architecture = {};
     D3D_SHADER_MODEL m_ShaderModel = D3D_SHADER_MODEL_6_0;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -42,7 +42,7 @@ clGetDeviceIDs(cl_platform_id   platform,
                 NumDevices++;
                 if (output < num_entries)
                 {
-                    devices[i] = device;
+                    devices[output++] = device;
                 }
             }
         }
@@ -611,6 +611,7 @@ void Device::CacheCaps(std::lock_guard<std::mutex> const&, ComPtr<ID3D12Device> 
     }
     spDevice->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE, &m_Architecture, sizeof(m_Architecture));
     spDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &m_D3D12Options, sizeof(m_D3D12Options));
+    spDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &m_D3D12Options1, sizeof(m_D3D12Options1));
     spDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS4, &m_D3D12Options4, sizeof(m_D3D12Options4));
 
     D3D_SHADER_MODEL SMTests[] = {


### PR DESCRIPTION
See https://github.com/microsoft/OpenCLOn12/issues/50

The previous algorithm did not gracefully handle odd/prime sizes. It would start with a default size, shrink to 1, and never expand again.

The new algorithm attempts to prime factorize the global size and add that into the local size. This continues until it hits a sweet spot for the device's wave size, >= min and < max (unless max == min). Failing to find a sweet spot, it'll just attempt to use one of the global dimensions as the local dimension.

This ended up being more similar to #51 than I expected when reading that change, though a few key differences: Don't allocate vectors of factors (just use an iterator into a static list), target the wave size instead of the max thread group size, prefer power-of-2 factorization instead of starting at the end of the list of factors.