### PR TITLE
Added info on how I understand OpenCLOn12's relations with the Microsoft Store "Compatibility Pack" app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This repository contains the implementations of the APIs. It depends on various 
 
 Additionally, DXIL.dll from the Windows SDK will be required at runtime to sign and validate the DXIL shaders produced by the compiler.
 
+Generally, OpenCLOn12 when installed through the Releases pages' `Universal_D3DMappingLayers_(...).appx` is the same app as the "[OpenCL™, OpenGL®, and Vulkan® Compatibility Pack](https://apps.microsoft.com/detail/9nqpsl29bfff)" app on Microsoft Store.
+
 For more details about OpenCLOn12, see:
 * [Product release blog post](https://devblogs.microsoft.com/directx/announcing-the-opencl-and-opengl-compatibility-pack-for-windows-10-on-arm)
 * [Microsoft blog post](https://devblogs.microsoft.com/directx/in-the-works-opencl-and-opengl-mapping-layers-to-directx/)


### PR DESCRIPTION
Running the .appx on my PC, had my system list OpenCLOn12 post-installation as being the exact same program as the Microsoft Store version ("OpenCL™, OpenGL®, and Vulkan® Compatibility Pack"), so I presume that adding info on it on this repo will make it more visible that the two of them are the same program, in case anyone e.g. are searching online for local installers of that app.

I've turned on the "Allow edits by maintainers" button, so you are free to (If you wish to) further modify this PR's changed file on your own without needing to ask me about it.