### PR TITLE
Handle unexpected cache invalidations

### DIFF
--- a/src/openclon12/cache.hpp
+++ b/src/openclon12/cache.hpp
@@ -5,6 +5,7 @@
 #include "d3d12.h"
 #include <memory>
 #include <utility>
+#include <shared_mutex>
 #include <wrl/client.h>
 
 class ShaderCache
@@ -29,9 +30,11 @@ public:
     FoundValue Find(const void* const* keys, const size_t* keySizes, unsigned keyParts);
 
     void Close();
+    void Clear();
 
 #ifdef __ID3D12ShaderCacheSession_INTERFACE_DEFINED__
 private:
     Microsoft::WRL::ComPtr<ID3D12ShaderCacheSession> m_pSession;
+    std::shared_mutex m_ResetLock;
 #endif
 };


### PR DESCRIPTION
It seems we're seeing issues with CLOn12 not working correctly when the OS version is upgraded but the driver isn't. The cached PSOs stored in the cache are considered invalid while the cache itself wasn't invalidated.

When PSO creation results in an error with the cached blob, clear the cache and try again.